### PR TITLE
MS Added dynamic env vars and annotations

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.8
-appVersion: 0.0.8
+version: 0.0.9
+appVersion: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -16,6 +16,7 @@ spec:
 {{- include "datarepo-api.labels" . | nindent 8 }}
         app: {{ include "datarepo-api.fullname" . }}
         component: {{ include "datarepo-api.fullname" . }}
+##  dynamically populates environment annotations
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
@@ -56,6 +57,7 @@ spec:
         ports:
         - containerPort: {{ .Values.image.port }}
         - containerPort: 5005
+##  dynamically populates environment variables
         env:
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -13,8 +13,11 @@ spec:
   template:
     metadata:
       labels:
+{{- include "datarepo-api.labels" . | nindent 8 }}
         app: {{ include "datarepo-api.fullname" . }}
         component: {{ include "datarepo-api.fullname" . }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       serviceAccountName: {{ include "datarepo-api.serviceAccountName" . }}
       volumes:
@@ -54,185 +57,11 @@ spec:
         - containerPort: {{ .Values.image.port }}
         - containerPort: 5005
         env:
-        {{- if .Values.env.serverContextpath }}
-        - name: SERVER_CONTEXTPATH
-          value: {{ .Values.env.serverContextpath | quote }}
+        {{- if .Values.env }}
+        {{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
         {{- end }}
-        {{- if .Values.env.serverPort }}
-        - name: SERVER_PORT
-          value: {{ .Values.env.serverPort | quote }}
-        {{- end }}
-        {{- if .Values.env.springDatasourceTomcatTestOnBorrow }}
-        - name: SPRING_DATASOURCE_TOMCAT_TEST-ON-BORROW
-          value: {{ .Values.env.springDatasourceTomcatTestOnBorrow | quote }}
-        {{- end }}
-        {{- if .Values.env.springDatasourceTomcatValidationQuery }}
-        - name: SPRING_DATASOURCE_TOMCAT_VALIDATION-QUERY
-          value: {{ .Values.env.springDatasourceTomcatValidationQuery | quote }}
-        {{- end }}
-        {{- if .Values.env.springJacksonSerializationWriteDatesAsTimestamps }}
-        - name: SPRING_JACKSON_SERIALIZATION_WRITE_DATES_AS_TIMESTAMPS
-          value: {{ .Values.env.springJacksonSerializationWriteDatesAsTimestamps | quote }}
-        {{- end }}
-        {{- if .Values.env.springLiquibaseEnabled }}
-        - name: SPRING_LIQUIBASE_ENABLED
-          value: {{ .Values.env.springLiquibaseEnabled | quote }}
-        {{- end }}
-        {{- if .Values.env.springProfilesActive }}
-        - name: SPRING_PROFILES_ACTIVE
-          value: {{ .Values.env.springProfilesActive | quote }}
-        {{- end }}
-        {{- if .Values.env.springfoxDocumentationSwaggerV2Path }}
-        - name: SPRINGFOX_DOCUMENTATION_SWAGGER_V2_PATH
-          value: {{ .Values.env.springfoxDocumentationSwaggerV2Path | quote }}
-        {{- end }}
-        {{- if .Values.env.dbMigrateDropallonstart }}
-        - name: DB_MIGRATE_DROPALLONSTART
-          value: {{ .Values.env.dbMigrateDropallonstart | quote }}
-        {{- end }}
-        {{- if .Values.env.dbMigrateUpdateallonstart | quote }}
-        - name: DB_MIGRATE_UPDATEALLONSTART
-          value: {{ .Values.env.dbMigrateUpdateallonstart | quote }}
-        {{- end }}
-        {{- if .Values.env.dbDatarepoUri }}
-        - name: DB_DATAREPO_URI
-          value: {{ .Values.env.dbDatarepoUri | quote }}
-        {{- end }}
-        {{- if .Values.env.dbDatarepoUsername }}
-        - name: DB_DATAREPO_USERNAME
-          value: {{ .Values.env.dbDatarepoUsername | quote }}
-        {{- end }}
-        {{- if .Values.env.dbDatarepoPassword }}
-        - name: DB_DATAREPO_PASSWORD
-          value: {{ .Values.env.dbDatarepoPassword | quote }}
-        {{- end }}
-        {{- if .Values.env.dbDatarepoChangesetfile }}
-        - name: DB_DATAREPO_CHANGESETFILE
-          value: {{ .Values.env.dbDatarepoChangesetfile | quote }}
-        {{- end }}
-        {{- if .Values.env.dbStairwayUri }}
-        - name: DB_STAIRWAY_URI
-          value: {{ .Values.env.dbStairwayUri | quote }}
-        {{- end }}
-        {{- if .Values.env.dbStairwayUsername }}
-        - name: DB_STAIRWAY_USERNAME
-          value: {{ .Values.env.dbStairwayUsername | quote }}
-        {{- end }}
-        {{- if .Values.env.dbStairwayPassword }}
-        - name: DB_STAIRWAY_PASSWORD
-          value: {{ .Values.env.dbStairwayPassword | quote }}
-        {{- end }}
-        {{- if .Values.env.dbStairwayChangesetfile }}
-        - name: DB_STAIRWAY_CHANGESETFILE
-          value: {{ .Values.env.dbStairwayChangesetfile | quote }}
-        {{- end }}
-        {{- if .Values.env.dbStairwayForceclean }}
-        - name: DB_STAIRWAY_FORCECLEAN
-          value: {{ .Values.env.dbStairwayForceclean | quote }}
-        {{- end }}
-        {{- if .Values.env.oauthClientid }}
-        - name: OAUTH_CLIENTID
-          value: {{ .Values.env.oauthClientid | quote }}
-        {{- end }}
-        {{- if .Values.env.oauthSchemename }}
-        - name: OAUTH_SCHEMENAME
-          value: {{ .Values.env.oauthSchemename | quote }}
-        {{- end }}
-        {{- if .Values.env.oauthLoginendpoint }}
-        - name: OAUTH_LOGINENDPOINT
-          value: {{ .Values.env.oauthLoginendpoint | quote }}
-        {{- end }}
-        {{- if .Values.env.oauthScopes }}
-        - name: OAUTH_SCOPES
-          value: {{ .Values.env.oauthScopes | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoResourceid }}
-        - name: DATAREPO_RESOURCEID
-          value: {{ .Values.env.datarepoResourceid | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoUseremail }}
-        - name: DATAREPO_USEREMAIL
-          value: {{ .Values.env.datarepoUseremail | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoDnsname }}
-        - name: DATAREPO_DNSNAME
-          value: {{ .Values.env.datarepoDnsname | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoUserid }}
-        - name: DATAREPO_USERID
-          value: {{ .Values.env.datarepoUserid | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoMaxstairwaythreads }}
-        - name: DATAREPO_MAXSTAIRWAYTHREADS
-          value: {{ .Values.env.datarepoMaxstairwaythreads | quote}}
-        {{- end }}
-        {{- if .Values.env.datarepoGcsBucket }}
-        - name: DATAREPO_GCS_BUCKET
-          value: {{ .Values.env.datarepoGcsBucket | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoGcsRegion }}
-        - name: DATAREPO_GCS_REGION
-          value: {{ .Values.env.datarepoGcsRegion | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoGcsConnecttimeoutseconds }}
-        - name: DATAREPO_GCS_CONNECTTIMEOUTSECONDS
-          value: {{ .Values.env.datarepoGcsConnecttimeoutseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoGcsReadtimeoutseconds }}
-        - name: DATAREPO_GCS_READTIMEOUTSECONDS
-          value: {{ .Values.env.datarepoGcsReadtimeoutseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.datarepoGcsAllowreuseexistingbuckets }}
-        - name: DATAREPO_GCS_ALLOWREUSEEXISTINGBUCKETS
-          value: {{ .Values.env.datarepoGcsAllowreuseexistingbuckets | quote }}
-        {{- end }}
-        {{- if .Values.env.samBasepath }}
-        - name: SAM_BASEPATH
-          value: {{ .Values.env.samBasepath | quote }}
-        {{- end }}
-        {{- if .Values.env.samStewardsgroupemail }}
-        - name: SAM_STEWARDSGROUPEMAIL
-          value: {{ .Values.env.samStewardsgroupemail | quote }}
-        {{- end }}
-        {{- if .Values.env.samRetryinitialwaitseconds }}
-        - name: SAM_RETRYINITIALWAITSECONDS
-          value: {{ .Values.env.samRetryinitialwaitseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.samRetrymaximumwaitseconds }}
-        - name: SAM_RETRYMAXIMUMWAITSECONDS
-          value: {{ .Values.env.samRetrymaximumwaitseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.samOperationtimeoutseconds }}
-        - name: SAM_OPERATIONTIMEOUTSECONDS
-          value: {{ .Values.env.samOperationtimeoutseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.googleProjectid }}
-        - name: GOOGLE_PROJECTID
-          value: {{ .Values.env.googleProjectid | quote }}
-        {{- end }}
-        {{- if .Values.env.googleApplicationname }}
-        - name: GOOGLE_APPLICATIONNAME
-          value: {{ .Values.env.googleApplicationname | quote }}
-        {{- end }}
-        {{- if .Values.env.googleProjectcreatetimeoutseconds | quote }}
-        - name: GOOGLE_PROJECTCREATETIMEOUTSECONDS
-          value: {{ .Values.env.googleProjectcreatetimeoutseconds | quote }}
-        {{- end }}
-        {{- if .Values.env.googleCorebillingaccount }}
-        - name: GOOGLE_COREBILLINGACCOUNT
-          value: {{ .Values.env.googleCorebillingaccount | quote }}
-        {{- end }}
-        {{- if .Values.env.googleParentresourcetype }}
-        - name: GOOGLE_PARENTRESOURCETYPE
-          value: {{ .Values.env.googleParentresourcetype | quote }}
-        {{- end }}
-        {{- if .Values.env.googleParentresourceid }}
-        - name: GOOGLE_PARENTRESOURCEID
-          value: {{ .Values.env.googleParentresourceid | quote }}
-        {{- end }}
-        {{- if .Values.env.itJadeApiUrl }}
-        - name: IT_JADE_API_URL
-          value: {{ .Values.env.itJadeApiUrl | quote }}
         {{- end }}
         {{ if $hasCredentials -}}
         - name: DB_DATAREPO_PASSWORD

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -20,7 +20,6 @@ fullnameOverride: ""
 ## Pod annotations
 podAnnotations: {}
 
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -10,56 +10,16 @@ image:
   pullPolicy: IfNotPresent
   port: 8080
 
-env:  # environment variables
-  serverContextpath:
-  serverPort:
-  springDatasourceTomcatTestOnBorrow:
-  springDatasourceTomcatValidationQuery:
-  springJacksonSerializationWriteDatesAsTimestamps:
-  springLiquibaseEnabled:
-  springProfilesActive:
-  springfoxDocumentationSwaggerV2Path:
-  dbMigrateDropallonstart:
-  dbMigrateUpdateallonstart:
-  dbDatarepoUri:
-  dbDatarepoUsername:
-  dbDatarepoPassword:
-  dbDatarepoChangesetfile:
-  dbStairwayUri:
-  dbStairwayUsername:
-  dbStairwayPassword:
-  dbStairwayChangesetfile:
-  dbStairwayForceclean:
-  oauthClientid:
-  oauthSchemename:
-  oauthLoginendpoint:
-  oauthScopes:
-  datarepoResourceid:
-  datarepoUseremail:
-  datarepoDnsname:
-  datarepoUserid:
-  datarepoMaxstairwaythreads:
-  datarepoGcsBucket:
-  datarepoGcsRegion:
-  datarepoGcsConnecttimeoutseconds:
-  datarepoGcsReadtimeoutseconds:
-  samBasepath:
-  samStewardsgroupemail:
-  samRetryinitialwaitseconds:
-  samRetrymaximumwaitseconds:
-  samOperationtimeoutseconds:
-  googleProjectid:
-  googleApplicationname:
-  googleProjectcreatetimeoutseconds:
-  googleCorebillingaccount:
-  googleParentresourcetype:
-  googleParentresourceid:
-  itJadeApiUrl:
-  datarepoGcsAllowreuseexistingbuckets:
+## Extra environment variables that will be pass onto deployment pods
+env: {}
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+## Pod annotations
+podAnnotations: {}
+
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.4
+appVersion: 0.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/datarepo-ui/templates/ui-deployment.yaml
+++ b/charts/datarepo-ui/templates/ui-deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
 {{- include "datarepo-ui.labels" . | nindent 8 }}
         component: {{ include "datarepo-ui.fullname" . }}
+##  dynamically populates environment annotations
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
@@ -23,6 +24,7 @@ spec:
         image: {{ if .Values.imageName }}{{ .Values.imageName }}{{ else }}"{{ .Values.image.repository }}:{{ .Values.image.tag }}"{{ end }}
         ports:
         - containerPort: 80
+##  dynamically populates environment variables
         env:
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}

--- a/charts/datarepo-ui/templates/ui-deployment.yaml
+++ b/charts/datarepo-ui/templates/ui-deployment.yaml
@@ -12,7 +12,10 @@ spec:
   template:
     metadata:
       labels:
+{{- include "datarepo-ui.labels" . | nindent 8 }}
         component: {{ include "datarepo-ui.fullname" . }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       serviceAccountName: {{ include "datarepo-ui.serviceAccountName" . }}
       containers:
@@ -20,6 +23,13 @@ spec:
         image: {{ if .Values.imageName }}{{ .Values.imageName }}{{ else }}"{{ .Values.image.repository }}:{{ .Values.image.tag }}"{{ end }}
         ports:
         - containerPort: 80
+        env:
+        {{- if .Values.env }}
+        {{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+        {{- end }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /status

--- a/charts/datarepo-ui/values.yaml
+++ b/charts/datarepo-ui/values.yaml
@@ -14,6 +14,12 @@ proxyPass:
   swagger:  # http://api-service.data-repo:8080/swagger-ui.html
   api:  # http://api-service.data-repo:8080
 
+## Extra environment variables that will be pass onto deployment pods
+env: {}
+
+## Pod annotations
+podAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.4
-appVersion: 0.0.4
+version: 0.0.5
+appVersion: 0.0.5
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
+++ b/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
@@ -12,8 +12,11 @@ spec:
   template:
     metadata:
       labels:
+{{- include "oidc-proxy.labels" . | nindent 8 }}
         app: {{ include "oidc-proxy.fullname" . }}
         component: {{ include "oidc-proxy.fullname" . }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
       serviceAccountName: {{ include "oidc-proxy.serviceAccountName" . }}
       containers:
@@ -39,22 +42,12 @@ spec:
           timeoutSeconds: 10
           failureThreshold: 3
         env:
-          - name: PROXY_URL
-            value: {{ .Values.env.proxyUrl | quote }}
-          - name: PROXY_URL2
-            value: {{ .Values.env.proxyUrl2 | quote }}
-          - name: PROXY_URL3
-            value: {{ .Values.env.proxyUrl3 | quote }}
-          - name: LOG_LEVEL
-            value: {{ .Values.env.logLevel | quote }}
-          - name: SERVER_NAME
-            value: {{ .Values.env.serverName | quote }}
-          - name: REMOTE_USER_CLAIM
-            value: {{ .Values.env.remoteUserClaim | quote }}
-          - name: ENABLE_STACKDRIVER
-            value: {{ .Values.env.enableStackdriver | quote }}
-          - name: FILTER2
-            value: {{ .Values.env.filter2 | quote }}
+        {{- if .Values.env }}
+        {{- range $key, $value := .Values.env }}
+        - name: "{{ $key }}"
+          value: "{{ $value }}"
+        {{- end }}
+        {{- end }}
         volumeMounts:
           - mountPath: /etc/apache2/sites-available/site.conf
             name: siteconf

--- a/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
+++ b/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
@@ -15,6 +15,7 @@ spec:
 {{- include "oidc-proxy.labels" . | nindent 8 }}
         app: {{ include "oidc-proxy.fullname" . }}
         component: {{ include "oidc-proxy.fullname" . }}
+##  dynamically populates environment annotations
       annotations:
 {{ toYaml .Values.podAnnotations | indent 8 }}
     spec:
@@ -41,6 +42,7 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
+##  dynamically populates environment variables
         env:
         {{- if .Values.env }}
         {{- range $key, $value := .Values.env }}

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -9,17 +9,11 @@ image:
   version: bernick_tcell
   pullPolicy: IfNotPresent
 
-env:
-# environment vars for Deployment
-  proxyUrl:   # first url path to proxy
-  proxyUrl2:  # second url path to proxy
-  proxyUrl3:  # third url path to proxy
-  logLevel: debug
-  serverName:   # A/CNAME
-  remoteUserClaim: sub
-  enableStackdriver: yes
-  filter2: AddOutputFilterByType DEFLATE application/json text/plain text/html application/javascript application/x-javascript
+## Extra environment variables that will be pass onto deployment pods
+env: {}
 
+## Pod annotations
+podAnnotations: {}
 
 imagePullSecrets: []
 nameOverride: ""
@@ -35,7 +29,6 @@ serviceAccount:
 rbac:
   # Specifies whether a psp should be created
   create: false
-
 
 service:
   type: NodePort


### PR DESCRIPTION
This makes it so the chart will not need to be updated when a new application environment variable is created and pod annotations can be added dynamically.

example api config:
```
env:
  GOOGLE_PROJECTID:  broad-jade-integration
  DB_DATAREPO_USERNAME:  drmanager
  SPRING_PROFILES_ACTIVE:  google,cloudsql,temp
  DB_STAIRWAY_USERNAME:  drmanager
  DB_STAIRWAY_URI: jdbc:postgresql://chart-test-gcloud-sqlproxy.temp:5432/stairway-temp
  DB_DATAREPO_URI: jdbc:postgresql://chart-test-gcloud-sqlproxy.temp:5432/datarepo-temp
  IT_JADE_API_URL: https://jade-temp.datarepo-integration.broadinstitute.org
  DATAREPO_GCS_ALLOWREUSEEXISTINGBUCKETS: true
```