### PR TITLE
DR-977: Bump action version to 0.6.0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,43 +32,43 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Whitelist Runner IP"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'gcp_whitelist'
           role_id: ${{ secrets.ROLE_ID }}
           secret_id: ${{ secrets.SECRET_ID }}
 
       - name: "Check for an availble namespace to deploy to and set state lock"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'k8_checknamespace'
           k8_namespaces: 'temp'
 
       - name: "Deploy chart to temp namespace"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'charttestdeploy'
           k8_namespaces: temp
 
       - name: "Simple test for chart deployment"
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'testcharts'
 
       - name: "Delete chart deployment after test"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'charttestdelete'
 
       - name: "Clean state lock from used Namespace on deploy"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'k8_checknamespace_clean'
 
       - name: "Clean whitelisted Runner IP"
         if: always()
-        uses: broadinstitute/datarepo-actions@0.5.0
+        uses: broadinstitute/datarepo-actions@0.6.0
         with:
           actions_subcommand: 'gcp_whitelist_clean'


### PR DESCRIPTION
The latest version of the GitHub action cleans the IAM policy before it is run:

- https://github.com/broadinstitute/datarepo-actions/pull/8
- https://github.com/broadinstitute/datarepo-actions/pull/9

The action version was automatically bumped and released: https://github.com/broadinstitute/datarepo-actions/releases/tag/0.6.0