### PR TITLE
Update deployment API to work for 1.16

### DIFF
--- a/charts/install-secrets-manager/Chart.yaml
+++ b/charts/install-secrets-manager/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/install-secrets-manager/templates/deployment.yaml
+++ b/charts/install-secrets-manager/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $hasCredentials := include "install-secrets-manager.hasCredentials" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:


### PR DESCRIPTION
As per https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

> Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served
> Migrate to use the apps/v1 API version, available since v1.9. Existing persisted data can be retrieved/updated via the new version.