### PR TITLE
bumped charts for gke 1.16

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.14
-appVersion: 0.0.14
+version: 0.0.15
+appVersion: 0.0.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $hasCredentials := include "datarepo-api.hasCredentials" . -}}
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "datarepo-api.fullname" . }}

--- a/charts/gcloud-sqlproxy/Chart.yaml
+++ b/charts/gcloud-sqlproxy/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.16"
+appVersion: "1.17"
 description: Google Cloud SQL Proxy
 engine: gotpl
 home: https://cloud.google.com/sql/docs/postgres/sql-proxy
@@ -18,4 +18,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/broadinstitute/datarepo-helm
-version: 0.19.5
+version: 0.19.6

--- a/charts/gcloud-sqlproxy/templates/deployment.yaml
+++ b/charts/gcloud-sqlproxy/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if ne (index .Values.cloudsql.instances 0).instance "instance" }}
 {{- $hasCredentials := include "gcloud-sqlproxy.hasCredentials" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gcloud-sqlproxy.fullname" . }}
@@ -11,9 +11,14 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicasCount }}
+  selector:
+    matchLabels:
+      app: {{ include "gcloud-sqlproxy.fullname" . }}
   template:
     metadata:
+      name: {{ include "gcloud-sqlproxy.fullname" . }}
       labels:
+        app: {{ include "gcloud-sqlproxy.fullname" . }}
         app.kubernetes.io/name: {{ include "gcloud-sqlproxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:

--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.8
-appVersion: 0.0.8
+version: 0.0.9
+appVersion: 0.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/oidc-ingress.yaml
+++ b/charts/oidc-proxy/templates/oidc-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "oidc-proxy.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $paths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

After this weekend fixing fakeprod, I had to modify the charts for the kubernetes 1.16 API depreciation. 