### PR TITLE
Extend probe timeouts

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.18
-appVersion: 0.0.18
+version: 0.0.19
+appVersion: 0.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           httpGet:
             path: /status
             port: {{ .Values.image.port }}
-          initialDelaySeconds: 25
+          initialDelaySeconds: 45
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 2
@@ -51,7 +51,7 @@ spec:
           httpGet:
             path: /status
             port: {{ .Values.image.port }}
-          initialDelaySeconds: 45
+          initialDelaySeconds: 60
           periodSeconds: 10
           timeoutSeconds: 3
           failureThreshold: 2


### PR DESCRIPTION
Our startup time continues to get longer and longer. It is a combination of additional liquidate migrations as well as more synchronization with stairway. I made the probe time significantly longer.