### PR TITLE
DR-1529 Enable CORS headers on requests served by the oidc proxy

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.13
-appVersion: 0.0.13
+version: 0.0.14
+appVersion: 0.0.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -21,6 +21,9 @@ data:
 
     Header unset X-Frame-Options
     Header always set X-Frame-Options SAMEORIGIN
+    Header always set Access-Control-Allow-Origin *
+    Header always set Access-Control-Allow-Headers DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Referer
+    Header always set Access-Control-Allow-Methods GET,POST,DELETE,PUT,PATCH,OPTIONS,HEAD
 
     ProxyTimeout ${PROXY_TIMEOUT}
     OIDCOAuthTokenIntrospectionInterval 60


### PR DESCRIPTION
This allows any origin but locks down which headers and methods will be passed through