### PR TITLE
DR-1529 Allow the x-app-id and origin headers to be passed in

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.14
-appVersion: 0.0.14
+version: 0.0.15
+appVersion: 0.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
     Header unset X-Frame-Options
     Header always set X-Frame-Options SAMEORIGIN
     Header always set Access-Control-Allow-Origin *
-    Header always set Access-Control-Allow-Headers DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Referer
+    Header always set Access-Control-Allow-Headers DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Referer,X-App-Id,Origin
     Header always set Access-Control-Allow-Methods GET,POST,DELETE,PUT,PATCH,OPTIONS,HEAD
 
     ProxyTimeout ${PROXY_TIMEOUT}


### PR DESCRIPTION
Since many terra apps use this.  This is a follow-on to my last PR where it looks like we need this based on WMS testing this out. Removing this header from their requests makes things work but looking at services like SAM, they allow this header so we probably should too.

Will do the chart updates as soon as this one is merged in...