### PR TITLE
Datarepo version update: 1.18.0

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.28
+version: 0.0.29
 appVersion: 1.18.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application


### PR DESCRIPTION
Update datarepo-api versions in **1.18.0**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/575524417).*