### PR TITLE
DR-1642 Lower the amount of memory requested to schedule a pod

### DIFF
--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -30,9 +30,9 @@ tolerations: []
 affinity: {}
 resources:
   limits:
-    memory: 3072Mi
-  requests:
     memory: 2560Mi
+  requests:
+    memory: 1536Mi
 serviceAccount:
   annotations: {}
   # Specifies whether a service account should be created


### PR DESCRIPTION
This will make it a bit easier for k8s to schedule a pod