### PR TITLE
Datarepo datarepo-api version update: 1.31.0

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,8 +12,8 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.38
-appVersion: 1.30.0
+version: 0.0.39
+appVersion: 1.31.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application
 # appVersion: 1.16.0

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -12,7 +12,7 @@ readinessInitialDelaySeconds: 90
 livenessInitialDelaySeconds: 90
 image:
   repository: gcr.io/broad-jade-dev/jade-data-repo
-  tag: 1.30.0
+  tag: 1.31.0
   pullPolicy: IfNotPresent
   port: 8080
 ## Extra environment variables that will be pass onto deployment pods


### PR DESCRIPTION
Update datarepo-api versions in **1.31.0**.
*Note: This PR was opened by the [update-env GitHub Actions workflow](https://github.com/DataBiosphere/jade-data-repo/actions/runs/594765260).*