### PR TITLE
[DR-1658] Add /ga4gh path to oidc-proxy

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.19
+version: 0.0.20
 appVersion: 0.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/oidc-proxy/ci/testing-values.yaml
+++ b/charts/oidc-proxy/ci/testing-values.yaml
@@ -2,7 +2,8 @@ fullnameOverride: test-oidc-proxy
 env:
   PROXY_URL: http://test-datarepo-ui.integration-temp:8080/
   PROXY_URL2: http://test-datarepo-api.integration-temp:8080/api
-  PROXY_URL3: http://test-datarepo-api.integration-temp:8080/register
+  PROXY_URL3: http://test-datarepo-api.integration-temp:8080/ga4gh
+  PROXY_PATH3: /ga4gh
   LOG_LEVEL: debug
   SERVER_NAME: jade.datarepo-integration.broadinstitute.org
   REMOTE_USER_CLAIM: sub

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -75,4 +75,22 @@ data:
 
             ${FILTER2}
         </Location>
+
+        <Location ${PROXY_PATH3}>
+            RewriteEngine On
+            RewriteCond %{REQUEST_METHOD} OPTIONS
+            RewriteRule ^(.*)$ $1 [R=204,L]
+
+            <Limit OPTIONS>
+                Require all granted
+            </Limit>
+
+            ${AUTH_TYPE3}
+            ${AUTH_REQUIRE3}
+
+            ProxyPass ${PROXY_URL3}
+            ProxyPassReverse ${PROXY_URL3}
+
+            ${FILTER3}
+        </Location>
     </VirtualHost>


### PR DESCRIPTION
Include the ga4gh endpoint in the oidc-proxy configmap. Note the [broadinstitute/openidc-proxy](https://github.com/broadinstitute/openidc-proxy#openidc-proxy) image used by the chart sets default values for some environment variables, so they are not all specified in the values.yaml.

I tested this change in my personal developer data repo deployment: https://github.com/broadinstitute/datarepo-helm-definitions/pull/387