### PR TITLE
DR-1650 remove nginx server tokens

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,6 @@ jobs:
         if: always()
         run: |
           helm delete test -n ${{ env.NAMESPACE }}
-          kubectl get podsecuritypolicies.policy | grep test| awk '{print $1}' | xargs kubectl delete podsecuritypolicies.policy
           kubectl delete pvc -n ${{ env.NAMESPACE }} --all
           kubectl delete namespace ${{ env.NAMESPACE }}
 

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
       proxy_temp_path /tmp/proxy_temp;
       client_body_temp_path /tmp/client_temp;
       include /etc/nginx/mime.types;
+      server_tokens off;
 
       server { # simple reverse-proxy
         listen       {{ .Values.nginxport }};


### PR DESCRIPTION
Setting `server_tokens` to `off` removes the version from the `server` response header header,.