### PR TITLE
DR-1651 Content-Security-Policy headers

### DIFF
--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -25,8 +25,15 @@ data:
       server { # simple reverse-proxy
         listen       {{ .Values.nginxport }};
 
-        # add a Content-Security-Policy
-        add_header Content-Security-Policy "default-src 'self';";
+        # add a Content-Security-Policy, with some variables to make formatting nice
+        set $DEFAULT "default-src 'self'";
+        set $SCRIPT "script-src 'self' 'unsafe-inline' apis.google.com *.gstatic.com *.broadinstitute.org";
+        set $STYLE "style-src 'self' 'unsafe-inline' fonts.googleapis.com";
+        set $IMG "img-src 'self' lh3.googleusercontent.com";
+        set $FONT "font-src 'self' fonts.googleapis.com fonts.gstatic.com";
+        set $CONNECT "connect-src 'self' *.broadinstitute.org account.google.com";
+        set $FRAME "frame-src 'self' accounts.google.com";
+        add_header Content-Security-Policy "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${IMG}; ${FONT}; ${CONNECT}; ${FRAME}";
 
         # pass the status check through
         location /status {

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -25,6 +25,9 @@ data:
       server { # simple reverse-proxy
         listen       {{ .Values.nginxport }};
 
+        # add a Content-Security-Policy
+        add_header Content-Security-Policy "default-src 'self';";
+
         # pass the status check through
         location /status {
             proxy_pass {{ .Values.proxyPass.status }};


### PR DESCRIPTION
We need to add [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy) headers to our UI nginx server to satisfy security requirements. We currently don't have the code set up to do nonces, so `unsafe-inline` has to be used in several places. I tested this in my personal deployment and kept adding domains until there were no errors when the page loaded.