### PR TITLE
DR-1652 Make sure that the Access-Control-Allow-Origin response header is always set

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.21
+version: 0.0.22
 appVersion: 0.0.19
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -39,7 +39,7 @@ data:
     # CORS header will ONLY be set if the Origin header was sent. The browser
     # does NOT set the Origin header on GETs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
     # Due to this change Access-Control-Allow-Origin '*' is never set.
-    Header set Access-Control-Allow-Origin %{ORIGIN_SUB_DOMAIN}e env=ORIGIN_SUB_DOMAIN
+    Header always set Access-Control-Allow-Origin %{ORIGIN_SUB_DOMAIN}e env=ORIGIN_SUB_DOMAIN
     Header merge Vary Origin
 
     ProxyTimeout ${PROXY_TIMEOUT}


### PR DESCRIPTION
This fixes an issue where the `Access-Control-Allow-Origin` wasn't getting set on `OPTIONS` requests.  Makes this `always`, the way it is for other CORS headers