### PR TITLE
DR-1769 Add jsagent.tcell.io to script-src

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.61
+version: 0.0.62
 appVersion: 0.43.0
 keywords:
   - google

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
 
         # add a Content-Security-Policy, with some variables to make formatting nice
         set $DEFAULT "default-src 'self'";
-        set $SCRIPT "script-src 'self' 'unsafe-inline' apis.google.com *.gstatic.com *.broadinstitute.org *.terra.bio *.envs-terra.bio";
+        set $SCRIPT "script-src 'self' 'unsafe-inline' apis.google.com *.gstatic.com *.broadinstitute.org *.terra.bio *.envs-terra.bio jsagent.tcell.io";
         set $STYLE "style-src 'self' 'unsafe-inline' fonts.googleapis.com";
         set $IMG "img-src 'self' data: *.googleusercontent.com *.terra.bio *.envs-terra.bio";
         set $FONT "font-src 'self' fonts.googleapis.com fonts.gstatic.com";


### PR DESCRIPTION
Missed one! We need this domain in the `script-src` section of the CSP headers for prod. It didn't show up in any other environment, and doesn't appear to break anything, but its good to not have errors in the console. Thanks to @nmalfroy for spotting this!