### PR TITLE
DR-1665 keep UI up when server down

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.60
+version: 0.0.62
 appVersion: 0.42.0
 keywords:
   - google

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.62
+version: 0.0.63
 appVersion: 0.42.0
 keywords:
   - google

--- a/charts/datarepo-ui/templates/ui-deployment.yaml
+++ b/charts/datarepo-ui/templates/ui-deployment.yaml
@@ -40,6 +40,26 @@ spec:
           value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        livenessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
+          initialDelaySeconds: 35
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
+          initialDelaySeconds: 45
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         volumeMounts:
           - name: nginxconf
             mountPath: /etc/nginx/nginx.conf

--- a/charts/datarepo-ui/templates/ui-deployment.yaml
+++ b/charts/datarepo-ui/templates/ui-deployment.yaml
@@ -40,22 +40,6 @@ spec:
           value: "{{ $value }}"
         {{- end }}
         {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /status
-            port: {{ .Values.nginxport }}
-          initialDelaySeconds: 35
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            path: /status
-            port: {{ .Values.nginxport }}
-          initialDelaySeconds: 45
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 3
         volumeMounts:
           - name: nginxconf
             mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
We're removing the readiness and liveliness probes from the UI server so that it stays up even when the API is down or returns a non-200 response. The UI will handle the error messaging to the user.
