### PR TITLE
DR-1771 dont install jq at runtime psql backup

### DIFF
--- a/charts/sqlbackup/Chart.yaml
+++ b/charts/sqlbackup/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to setup psql backups for a desinated time frame
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version
-version: 0.0.1
+version: 0.0.2
 appVersion: 0.0.1
 keywords:
 - google

--- a/charts/sqlbackup/values.yaml
+++ b/charts/sqlbackup/values.yaml
@@ -3,8 +3,8 @@ create-secret-manager-secret:
   enabled: false
 
 image:
-  repository: google/cloud-sdk
-  version: alpine
+  repository: broadinstitute/dsde-toolbox
+  version: master
   pullPolicy: IfNotPresent
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
AppSec currently gets nightly alerts about our psql backup because we install `jq` at runtime. By using `broadinstitute/dsde-toolbox`, we can remove the install of `jq` without needing to host our own image. The image is a little bigger (~1.5GB), but given that its only ever localized upon deploy, I don't think it's too big of a deal, especially since the compressed size is only ~350MB, which is what would get transferred over the network.

We need to specify full paths to `gcloud` within the scripts since `dsde-toolbox` doesn't add the Google Cloud SDK binaries to the `PATH`. I rendered the chart locally, and manually ran the list-backups command within a local `dsde-toolbox` container, and it spit out all the backups as expected. I'm unsure of how we would test this in kubernetes, since its only ever deployed to prod.