### PR TITLE
DDO-1814 Fix issue where `kubectl rollout` breaks ArgoCD syncs for TDR

### DIFF
--- a/charts/gcloud-sqlproxy/templates/deployment.yaml
+++ b/charts/gcloud-sqlproxy/templates/deployment.yaml
@@ -21,8 +21,9 @@ spec:
         app: {{ include "gcloud-sqlproxy.fullname" . }}
         app.kubernetes.io/name: {{ include "gcloud-sqlproxy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-      annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations: {{ toYaml .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ include "gcloud-sqlproxy.fullname" . }}


### PR DESCRIPTION
https://broadinstitute.slack.com/archives/CADM7MZ35/p1639406743425800

`kubectl` rollout commands run against the gcloud sqlproxy deployment cause ArgoCD to think TDR is out of sync.

<img width="1176" alt="Screen Shot 2021-12-13 at 10 02 41 AM" src="https://user-images.githubusercontent.com/60902147/145838876-172752e4-11d9-4ad0-854b-33bff9c6a118.png">

This seems to be because the deployment manifest sets annotations to `{}`, which makes ArgoCD think the resource should have NO annotations. Unfortunately syncing does not remove the extraneous annotations. It just means that ArgoCD goes out of sync immediately after a sync is triggerd.

This causes Terra's deploy process to fail, because it waits for ArgoCD apps to become healthy after syncing.