### PR TITLE
Switch Elasticsearch OSS image to patched version

### DIFF
--- a/charts/de-elasticsearch/values.yaml
+++ b/charts/de-elasticsearch/values.yaml
@@ -10,8 +10,8 @@ elasticsearch:
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html
 
   replicas: 3
-  image: "docker.elastic.co/elasticsearch/elasticsearch-oss"
-  imageTag: "7.10.2"
+  image: "gcr.io/broad-dsp-gcr-public/elasticsearch/elasticsearch-oss"
+  imageTag: "7.10.2-patched"
   imagePullPolicy: "IfNotPresent"
 
   # We'll probably want to tweak this, leaving as default for now,


### PR DESCRIPTION
I ran the following Dockerfile:

```
FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2

RUN yum -y update \
  && cd /usr/share/elasticsearch/lib \
  && curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.16.0/log4j-api-2.16.0.jar \
  && curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.16.0/log4j-core-2.16.0.jar \
  && rm log4j-*-2.11.1.jar
```

It updates the base software in CentOS, updates the elasticsearch log4j jars, and removes the old jars.