### PR TITLE
DC-97: Update elasticsearch-oss with latest log4j

### DIFF
--- a/charts/de-elasticsearch/Chart.yaml
+++ b/charts/de-elasticsearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: de-elasticsearch
 description: A Helm chart for elastic search in data explorer
 type: application
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - email: tjiang@broadinstitute.org
     name: tjiang

--- a/charts/de-elasticsearch/values.yaml
+++ b/charts/de-elasticsearch/values.yaml
@@ -11,7 +11,7 @@ elasticsearch:
 
   replicas: 3
   image: "us.gcr.io/broad-dsp-gcr-public/elasticsearch/elasticsearch-oss"
-  imageTag: "7.10.2-patched"
+  imageTag: "7.10.2-log4j-2.17.1"
   imagePullPolicy: "IfNotPresent"
 
   # We'll probably want to tweak this, leaving as default for now,


### PR DESCRIPTION
This is a two part PR. In the first PR, I update the elasticsearch container and the helm chart. In the second PR, I update the datarepo umbrella helm chart.

The Dockerfile that generated the container:

```
FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2

RUN yum -y update \
  && cd /usr/share/elasticsearch/lib \
  && curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar \
  && curl -O https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar \
  && rm log4j-*-2.11.1.jar
```