### PR TITLE
DR-2331 Don't forward the shutdown request from the UI to the service

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.112
+version: 0.0.113
 appVersion: 0.93.0
 keywords:
   - google

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -40,11 +40,6 @@ data:
             proxy_pass {{ .Values.proxyPass.status }};
         }
 
-        # pass the shutdown through, too
-        location /shutdown {
-            proxy_pass {{ .Values.proxyPass.shutdown }};
-        }
-
         # get swagger working
         location /swagger-ui.html {
             proxy_pass {{ .Values.proxyPass.swagger }};

--- a/charts/datarepo-ui/values.yaml
+++ b/charts/datarepo-ui/values.yaml
@@ -13,8 +13,6 @@ nginxport: 8080
 proxyPass:
   status:
   # http://api-service.data-repo:8080/status
-  shutdown:
-  # http://api-service.data-repo:8080/shutdown
   swagger:
   # http://api-service.data-repo:8080/swagger-ui.html
   api:

--- a/charts/datarepo/ci/testing-values.yaml
+++ b/charts/datarepo/ci/testing-values.yaml
@@ -72,7 +72,6 @@ datarepo-ui:
     tag: 0.73.0
   proxyPass:
     status: http://test-datarepo-api.integration-temp:8080/status
-    shutdown: http://test-datarepo-api.integration-temp:8080/shutdown
     swagger: http://test-datarepo-api.integration-temp:8080/swagger-ui.html
     api: http://test-datarepo-api.integration-temp:8080
   serviceAccount:


### PR DESCRIPTION
This makes it so that you can't call the shutdown endpoint from the web (it will just redirect you in the UI)