### PR TITLE
DR-2346 Pause before running the umbrella release action

### DIFF
--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -47,6 +47,11 @@ jobs:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
           CR_SKIP_EXISTING: "true"
 
+      - name: Pause between chart release and creation of new umbrella chart
+        id: wait
+        run: |
+          sleep 30
+
       - name: "Create new umbrella chart"
         uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
 


### PR DESCRIPTION
There appears to be some race condition that causes the action after the pause to fail pretty regularly.  Seeing if adding a pause here helps