### PR TITLE
DR-2331 Remove shutdown test value

### DIFF
--- a/charts/datarepo/ci/testing-values.yaml
+++ b/charts/datarepo/ci/testing-values.yaml
@@ -72,7 +72,6 @@ datarepo-ui:
     tag: 0.73.0
   proxyPass:
     status: http://test-datarepo-api.integration-temp:8080/status
-    shutdown: http://test-datarepo-api.integration-temp:8080/shutdown
     swagger: http://test-datarepo-api.integration-temp:8080/swagger-ui.html
     api: http://test-datarepo-api.integration-temp:8080
   serviceAccount:


### PR DESCRIPTION
Now that the chart is merged without the shutdown value, we don't need to pass it in to the chart test