### PR TITLE
PROD-634 Use an encrypted cache

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.27
-appVersion: 0.0.27
+version: 0.0.28
+appVersion: 0.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -46,6 +46,7 @@ data:
 
     ProxyTimeout ${PROXY_TIMEOUT}
     OIDCOAuthTokenIntrospectionInterval 60
+    OIDCCacheEncrypt On
 
     <VirtualHost _default_:${HTTPD_PORT}>
         ServerAdmin ${SERVER_ADMIN}


### PR DESCRIPTION
...which a) is better b) has the benefit of shrinking the data of what gets cached to fix the issue where tokens returned by google grew in size due to padding