### PR TITLE
[PROD-634] Use GET instead of POST for the OAuth2 introspection endpoint

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.29
-appVersion: 0.0.29
+version: 0.0.30
+appVersion: 0.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -51,6 +51,9 @@ data:
     # 2. it causes intermittent duplicate requests between the proxy and the underlying app
     # the latter side effect is too dangerous, so cache encryption is off
     OIDCCacheEncrypt Off
+    # Use GET for the introspection endpoint to avoid a performance issue with POST requests.
+    # See https://broadworkbench.atlassian.net/browse/PROD-634
+    OIDCOAuthIntrospectionEndpointMethod GET
 
     <VirtualHost _default_:${HTTPD_PORT}>
         ServerAdmin ${SERVER_ADMIN}


### PR DESCRIPTION
Same fix as https://github.com/broadinstitute/firecloud-develop/pull/2802.

Updates Terra Data Repo.