### PR TITLE
DDO-1674 Accelerate Metric Reporting for Data Repo

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.306
+version: 0.0.307
 appVersion: 1.303.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -28,3 +28,9 @@ maintainers:
 sources:
   - https://github.com/broadinstitute/datarepo-helm/tree/master/charts
 home: https://broadinstitute.github.io/datarepo-helm/
+dependencies:
+  # For Collecting Accelerate metrics from data repo in dsp-grafana dashboards
+  - name: sherlock-reporter
+    condition: sherlock.enabled
+    version: 0.5.0
+    repository: 'https://terra-helm.storage.googleapis.com'

--- a/charts/datarepo-api/templates/deployReport.yaml
+++ b/charts/datarepo-api/templates/deployReport.yaml
@@ -1,0 +1,8 @@
+# The purpose of this file is to create a k8s Job that reports
+# deploys of new application builds to sherlock (Terra's environment tracking service)
+# after each argo sync
+{{- if .Values.sherlock.enabled }}
+{{ template "sherlock-reporter.secret" . }}
+---
+{{ template "sherlock-reporter.job" . }}
+{{- end -}}

--- a/charts/datarepo-api/templates/deployReport.yaml
+++ b/charts/datarepo-api/templates/deployReport.yaml
@@ -1,7 +1,7 @@
+{{- if .Values.sherlock.enabled }}
 # The purpose of this file is to create a k8s Job that reports
 # deploys of new application builds to sherlock (Terra's environment tracking service)
 # after each argo sync
-{{- if .Values.sherlock.enabled }}
 {{ template "sherlock-reporter.secret" . }}
 ---
 {{ template "sherlock-reporter.job" . }}

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -79,7 +79,7 @@ existingSecretRBS: ""
 ## The key in the existing secret that stores the RBS service account credentials
 existingRBSSecretKey: ""
 
-# Sherlock is DSP's internal tool for tracking service deployments across all of terra and 
+# Sherlock is DSP's internal tool for tracking service deployments across all of terra and
 # extracting metric data from them. https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance
 sherlock:
   # This will only be enabled in environments managed by argocd

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -78,3 +78,18 @@ existingSynapsePasswordSecretKey: ""
 existingSecretRBS: ""
 ## The key in the existing secret that stores the RBS service account credentials
 existingRBSSecretKey: ""
+
+# Sherlock is DSP's internal tool for tracking service deployments across all of terra and 
+# extracting metric data from them. https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance
+sherlock:
+  # This will only be enabled in environments managed by argocd
+  enabled: false
+  # The library chart used here does not have access to .Values.image.repository
+  # thus a small amount of duplication is required here
+  appImageName: gcr.io/broad-jade-dev/jade-data-repo
+  appName: datarepo-api
+  sherlockImageTag: v0.0.19
+
+  vault:
+    # client certificate credentials used to authenticate to sherlock
+    pathPrefix: secret/suitable/sherlock/prod

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.132
+version: 0.0.133
 appVersion: 0.112.0
 keywords:
   - google

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -15,3 +15,9 @@ maintainers:
 sources:
   - https://github.com/broadinstitute/datarepo-helm/tree/master/charts
 home: https://broadinstitute.github.io/datarepo-helm/
+dependencies:
+  # For collecting accelerate metrics from data repo in dsp-grafana dashboards
+  - name: sherlock-reporter
+    condition: sherlock.enabled
+    version: 0.5.0
+    repository: 'https://terra-helm.storage.googleapis.com'

--- a/charts/datarepo-ui/templates/deployReport.yaml
+++ b/charts/datarepo-ui/templates/deployReport.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.sherlock.enabled }}
+# The purpose of this file is to create a k8s Job that reports
+# deploys of new application builds to sherlock (Terra's environment tracking service)
+# after each argo sync
+{{ template "sherlock-reporter.secret" . }}
+---
+{{ template "sherlock-reporter.job" . }}
+{{- end -}}

--- a/charts/datarepo-ui/values.yaml
+++ b/charts/datarepo-ui/values.yaml
@@ -47,3 +47,18 @@ rbac:
 service:
   type: ClusterIP
   port: 8080
+
+# Sherlock is DSP's internal tool for tracking service deployments across all of terra and
+# extracting metric data from them. https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance
+sherlock:
+  # This will only be enabled in environments managed by argocd
+  enabled: false
+  # The library chart used here does not have access to .Values.image.repository
+  # thus a small amount of duplication is required here
+  appImageName: gcr.io/broad-jade-dev/jade-data-repo-ui
+  appName: datarepo-ui
+  sherlockImageTag: v0.0.19
+
+  vault:
+    # client certificate credentials used to authenticate to sherlock
+    pathPrefix: secret/suitable/sherlock/prod


### PR DESCRIPTION
This PR adds support for adding accelerate metrics reporting to `datarepo-api` and `datarepo-ui`. I handled them separately because from what I could telll they are independently versioned and released.  Long story short this means that `datarepo-api` and `datarepo-ui` will show up on [this dashboard](https://grafana.dsp-devops.broadinstitute.org/d/hUZ3X92nk/terra?orgId=1). 

If I'm understanding the workflow in this repo correctly, once this is merged I then need to version bump the `datarepo-api` and `datarepo-ui` dependencies in the `datarepo` umbrella chart in a separate PR?

### How this works
This PR is leveraging a [helm library chart](https://helm.sh/docs/topics/library_charts). These are yaml template definitions which are usable across multiple different helm charts. `deployReport.yaml` is the library chart being invoked. The 2 templates that are actually getting rendered are defined [here](https://github.com/broadinstitute/terra-helmfile/tree/master/charts/sherlock-reporter/templates). 

This adds a k8s job which runs in it's own pod entirely isolated from datarepo. The job is essentially a `curl` command to report service deploy events and some metadata on them to dsp-devops' environment tracking service. The secret just contains a client sa for the job to authenticate to the environment tracking service. This service's working name is sherlock hence the references to that name in the changes here. 

The kubernetes Job itself leverages [argocd's hook features](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/), specifically `postSync`. This means this job will only ever run after all of datarepo's other k8s resources have successfully synced during a deployment. This functionality will only be enabled in environment's managed by Argocd. 