### PR TITLE
DDO-1674 Account for more restrictive Pod Security Policies

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.307
+version: 0.0.308
 appVersion: 1.303.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application
@@ -32,5 +32,5 @@ dependencies:
   # For Collecting Accelerate metrics from data repo in dsp-grafana dashboards
   - name: sherlock-reporter
     condition: sherlock.enabled
-    version: 0.5.0
+    version: 0.6.0
     repository: 'https://terra-helm.storage.googleapis.com'

--- a/charts/datarepo-ui/Chart.lock
+++ b/charts/datarepo-ui/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: sherlock-reporter
-  repository: https://terra-helm.storage.googleapis.com
-  version: 0.5.0
-digest: sha256:25e4880857ea09128ee5543c1c036ca7dea0abc6c67535f4f3d6a0716b80edf3
-generated: "2022-03-04T14:33:24.396227687Z"

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.134
+version: 0.0.135
 appVersion: 0.113.0
 keywords:
   - google
@@ -19,5 +19,5 @@ dependencies:
   # For collecting accelerate metrics from data repo in dsp-grafana dashboards
   - name: sherlock-reporter
     condition: sherlock.enabled
-    version: 0.5.0
+    version: 0.6.0
     repository: 'https://terra-helm.storage.googleapis.com'


### PR DESCRIPTION
The pod security policies in the data-repo chart are more restrictive than those in the rest of terra. Updatiing the metrics reporter to account for this.