### PR TITLE
DD-1918 added new *.envs-terra.bio to allowed domains for csp

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.143
-appVersion: 0.121.0
+version: 0.0.144
+appVersion: 0.122.0
 keywords:
   - google
   - cloud

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -31,7 +31,7 @@ data:
         set $STYLE "style-src 'self' 'unsafe-inline' fonts.googleapis.com";
         set $IMG "img-src 'self' data: *.googleusercontent.com *.terra.bio *.envs-terra.bio";
         set $FONT "font-src 'self' fonts.googleapis.com fonts.gstatic.com";
-        set $CONNECT "connect-src 'self' *.broadinstitute.org account.google.com *.googleapis.com";
+        set $CONNECT "connect-src 'self' *.envs-terra.bio *.broadinstitute.org account.google.com *.googleapis.com";
         set $FRAME "frame-src 'self' accounts.google.com";
         add_header Content-Security-Policy "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${IMG}; ${FONT}; ${CONNECT}; ${FRAME}";
 


### PR DESCRIPTION
otherwise react explodes, complaining that the domain is not trusted and TDR fails to complete loading.

This is required for BEEs as we will be using *.envs-terra.bio as a domain.

disclaimer: Not sure what the policy here is for merging, so I'm just creating this PR and pinging people for now.