### PR TITLE
Ddo 2017 local postgres for bees

### DIFF
--- a/charts/datarepo/Chart.lock
+++ b/charts/datarepo/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: postgres
   repository: https://terra-helm.storage.googleapis.com/
   version: 0.26.0
-digest: sha256:d4f39d758fbd2f614aa2c79e1a06edc929eda512db60dec4b009c854e8d7ae00
-generated: "2022-05-16T21:50:45.095308268Z"
+digest: sha256:32aaa8699f781fd80fd19176e80d669c3f98d58a2459c6a448a8530ecad0d9b9
+generated: "2022-05-17T10:01:31.669424-07:00"

--- a/charts/datarepo/Chart.lock
+++ b/charts/datarepo/Chart.lock
@@ -17,5 +17,8 @@ dependencies:
 - name: de-elasticsearch
   repository: https://broadinstitute.github.io/datarepo-helm/
   version: 0.1.4
+- name: postgres
+  repository: https://terra-helm.storage.googleapis.com/
+  version: 0.26.0
 digest: sha256:d4f39d758fbd2f614aa2c79e1a06edc929eda512db60dec4b009c854e8d7ae00
 generated: "2022-05-16T21:50:45.095308268Z"

--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: de-elasticsearch.enabled
 - name: postgres
-  version: 0.21.0
+  version: 0.22.0
   repository: https://terra-helm.storage.googleapis.com/
-  condition: postgresql.enabled
+  condition: postgres.enabled

--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: de-elasticsearch.enabled
 - name: postgres
-  version: 0.22.0
+  version: 0.26.0
   repository: https://terra-helm.storage.googleapis.com/
   condition: postgres.enabled

--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -51,3 +51,7 @@ dependencies:
   version: 0.1.4
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: de-elasticsearch.enabled
+- name: postgres
+  version: 0.21.0
+  repository: https://terra-helm.storage.googleapis.com/
+  condition: postgresql.enabled

--- a/charts/datarepo/values.yaml
+++ b/charts/datarepo/values.yaml
@@ -120,8 +120,10 @@ oidc-proxy:
   ##      faketlscert
   ##      -----END CERTIFICATE-----
 
-postgresql: # supply your Gcloudsql instance or use this
+# enable local postgres chart deployment (rather than external cloudsql)
+postgres: 
   enabled: false
+
 ## https://github.com/helm/charts/tree/master/stable/postgresql
 create-secret-manager-secret:
   enabled: false

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -78,3 +78,15 @@ ingress:
     - https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0/.well-known/openid-configuration
     - https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0/.well-known/openid-configuration
     - https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0/.well-known/openid-configuration
+
+# 
+# New fields by DevOps
+#
+
+# use cert-manager to rotate certs
+cert-manager:
+  enabled: false
+
+# use external-dns to manage dns provisioning
+externalDNS:
+  enabled: false

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -79,7 +79,7 @@ ingress:
     - https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0/.well-known/openid-configuration
     - https://tdrb2ctest.b2clogin.com/tdrb2ctest.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN_TDR/v2.0/.well-known/openid-configuration
 
-# 
+#
 # New fields by DevOps
 #
 


### PR DESCRIPTION
1) adds a dependency chart `postgres` from `terra-helmfile` for BEEs to be able to have postgres-in-k8s
2) removes the `postgresql` helm chart value, as it looks unused
3) added new `postgres` helm chart value to stay consistent with other places. Also did not want to have two similarly named variables.



Also, got a linting error trying to update values, looks like a false positive but dunno.

```{22-04-11 15:03}wm365-d96:~/codes/datarepo-helm@DDO-2017-local-postgres-for-BEEs✗✗✗✗✗✗ juyang% git commit -m "changes values instances of 'postgresql' to 'postgres' as far as I can tell that's an unused flag, also, chart bump"
charts/datarepo/values.yaml:24:  ##  "type": "service_account"
charts/datarepo/values.yaml:73:  ##  "type": "service_account"

[ERROR] Matched one or more prohibited patterns

Possible mitigations:
- Mark false positives as allowed using: git config --add secrets.allowed ...
- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory
- List your configured patterns: git config --get-all secrets.patterns
- List your configured allowed patterns: git config --get-all secrets.allowed
- List your configured allowed patterns in .gitallowed at repository's root directory
- Use --no-verify if this is a one-time false positive
{22-04-11 15:03}wm365-d96:~/codes/datarepo-helm@DDO-2017-local-postgres-for-BEEs✗✗✗✗✗✗ juyang% git commit -m "changes values instances of 'postgresql' to 'postgres' as far as I can tell that's an unused flag, also, chart bump" --no-verify```