### PR TITLE
DR-2504 OIDC config support

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.145
-appVersion: 0.122.0
+version: 0.0.146
+appVersion: 0.123.0
 keywords:
   - google
   - cloud

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -21,7 +21,11 @@ data:
       client_body_temp_path /tmp/client_temp;
       include /etc/nginx/mime.types;
       server_tokens off;
-
+    
+      # Needed for chunked responses (for oauth2 proxying)
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+    
       server { # simple reverse-proxy
         listen       {{ .Values.nginxport }};
 
@@ -45,7 +49,7 @@ data:
             proxy_pass {{ .Values.proxyPass.swagger }};
         }
 
-        location ~ (configuration|ga4gh|webjars|api-docs|data-repository-openapi|swagger-resources) {
+        location ~ (configuration|ga4gh|webjars|api-docs|data-repository-openapi|swagger-resources|oauth2) {
             proxy_pass {{ .Values.proxyPass.api }};
         }
 

--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.31
-appVersion: 0.0.31
+version: 0.0.32
+appVersion: 0.0.32
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.16.0

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
     ServerTokens ProductOnly
     TraceEnable off
 
-    LogFormat "%h %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{Origin}i\" \"%{User-Agent}i\"" combined
     LogFormat "%{X-Forwarded-For}i %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
     SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
     CustomLog "/dev/stdout" combined env=!forwarded
@@ -131,6 +131,7 @@ data:
             RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
             RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
             RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
+            RequestHeader set oidc_claim_expires_in "expr=%{HTTP:OAUTH2_CLAIM_exp}"
 
             ProxyPass ${PROXY_URL2}
             ProxyPassReverse ${PROXY_URL2}
@@ -164,6 +165,7 @@ data:
             RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
             RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
             RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
+            RequestHeader set oidc_claim_expires_in "expr=%{HTTP:OAUTH2_CLAIM_exp}"
 
             ProxyPass ${PROXY_URL3}
             ProxyPassReverse ${PROXY_URL3}

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -12,12 +12,14 @@ data:
     ServerTokens ProductOnly
     TraceEnable off
 
-    LogFormat "%h %l %u \"%{OIDC_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%{X-Forwarded-For}i %l %u \"%{OIDC_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+    LogFormat "%h %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%{X-Forwarded-For}i %l %u \"%{OAUTH2_CLAIM_email}i\" \"%{X-App-ID}i\" [%{%FT%T}t.%{msec_frac}t%{%z}t] %D %X \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
     SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
     CustomLog "/dev/stdout" combined env=!forwarded
     CustomLog "/dev/stdout" proxy env=forwarded
     LogLevel ${LOG_LEVEL}
+    
+    AddType application/x-httpd-php .php
 
     Header unset X-Frame-Options
     Header always set X-Frame-Options SAMEORIGIN
@@ -68,7 +70,24 @@ data:
         ErrorLog /dev/stdout
         CustomLog "/dev/stdout" combined
 
-        <Location ${PROXY_PATH}>
+        DocumentRoot /app
+        
+        <Directory "/app">
+          AllowOverride All
+          Options -Indexes
+          
+          Order allow,deny
+          Allow from all
+        </Directory>
+
+        <Location /introspect/>
+            RewriteEngine off
+            Require all granted
+            AuthType None
+        </Location>
+    
+        <LocationMatch "^(?!/introspect/)(${PROXY_PATH})(.*)">
+            RewriteEngine On
             RewriteCond %{REQUEST_METHOD} OPTIONS
             RewriteRule ^(.*)$ $1 [R=204,L]
 
@@ -79,11 +98,11 @@ data:
             ${AUTH_TYPE}
             ${AUTH_REQUIRE}
 
-            ProxyPass ${PROXY_URL}
+            ProxyPassMatch ${PROXY_URL}$2
             ProxyPassReverse ${PROXY_URL}
 
             ${FILTER}
-        </Location>
+        </LocationMatch>
 
         <Location ${PROXY_PATH2}>
             RewriteEngine On
@@ -95,7 +114,23 @@ data:
             </Limit>
 
             ${AUTH_TYPE2}
-            ${AUTH_REQUIRE2}
+            <RequireAll>
+              <RequireAll>
+                ${AUTH_REQUIRE2}
+              </RequireAll>
+              <RequireAll>
+                # Note: we need to reference %{REMOTE_USER} to ensure that this expression is evaluated _after_ the authentication has happened
+                # %{REMOTE_USER} != %{REMOTE_USER} will never evaluate to true but will ensure that the expression is evaluated at the correct time
+                # An example expression can look like:
+                # Require expr "%{REMOTE_USER} != %{REMOTE_USER} || %{HTTP:OAUTH2_CLAIM_email} =~ /.gserviceaccount.com$/"
+                Require expr "%{REMOTE_USER} != %{REMOTE_USER} || ('${ENVIRONMENT}' in {'dev', 'alpha', 'perf', 'staging', 'prod'} && (${ALLOW_EXPRESSION}))"
+              </RequireAll>
+            </RequireAll>
+
+
+            RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
+            RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
+            RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
 
             ProxyPass ${PROXY_URL2}
             ProxyPassReverse ${PROXY_URL2}
@@ -113,7 +148,22 @@ data:
             </Limit>
 
             ${AUTH_TYPE3}
-            ${AUTH_REQUIRE3}
+            <RequireAll>
+              <RequireAll>
+                ${AUTH_REQUIRE3}
+              </RequireAll>
+              <RequireAll>
+                # Note: we need to reference %{REMOTE_USER} to ensure that this expression is evaluated _after_ the authentication has happened
+                # %{REMOTE_USER} != %{REMOTE_USER} will never evaluate to true but will ensure that the expression is evaluated at the correct time
+                # An example expression can look like:
+                # Require expr "%{REMOTE_USER} != %{REMOTE_USER} || %{HTTP:OAUTH2_CLAIM_email} =~ /.gserviceaccount.com$/"
+                Require expr "%{REMOTE_USER} != %{REMOTE_USER} || ('${ENVIRONMENT}' in {'dev', 'alpha', 'perf', 'staging', 'prod'} && (${ALLOW_EXPRESSION}))"
+              </RequireAll>
+            </RequireAll>
+
+            RequestHeader set oidc_claim_email "expr=%{HTTP:OAUTH2_CLAIM_email}"
+            RequestHeader set oidc_claim_user_id "expr=%{HTTP:OAUTH2_CLAIM_sub}"
+            RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
 
             ProxyPass ${PROXY_URL3}
             ProxyPassReverse ${PROXY_URL3}
@@ -128,4 +178,14 @@ data:
             ProxyPass https://bigquery.googleapis.com/bigquery
             ProxyPassReverse https://bigquery.googleapis.com/bigquery
         </Location>
+    
+        # Oauth proxying logic.  This allows sending unauthed oauth requests through to the back end
+        <Location /oauth2>
+            ProxyPass ${PROXY_URL}oauth2
+            ProxyPassReverse ${PROXY_URL}oauth2
+        </Location>
     </VirtualHost>
+
+  oauth2conf: |-
+    OAuth2TokenVerify metadata {{ .Values.oidc.b2cMetadataEndpoint }} metadata.ssl_verify=true&verify.iat=skip
+    OAuth2TokenVerify introspect http://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.iat=skip

--- a/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
+++ b/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
@@ -62,6 +62,9 @@ spec:
           - mountPath: /etc/apache2/sites-available/site.conf
             name: siteconf
             subPath: site.conf
+          - mountPath: /etc/apache2/mods-enabled/oauth2.conf
+            name: oauth2conf
+            subPath: oauth2.conf
       volumes:
         {{- if or .Values.tcell.tcellSecret .Values.tcell.tcellSecretKey }}
         - name: tcell
@@ -77,6 +80,12 @@ spec:
             items:
               - key: siteconf
                 path: site.conf
+        - name: oauth2conf
+          configMap:
+            name: {{ template "oidc-proxy.fullname" . }}
+            items:
+              - key: oauth2conf
+                path: oauth2.conf
 
 {{- if .Values.resources }}
         resources:

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -4,9 +4,11 @@
 
 replicaCount: 1
 
+## Versions can be found here:
+## https://github.com/broadinstitute/openidc-terra-proxy/tags
 image:
-  repository: broadinstitute/openidc-proxy
-  version: bernick_tcell
+  repository: us.gcr.io/broad-dsp-gcr-public/openidc-terra-proxy
+  version: v0.1.12
   pullPolicy: IfNotPresent
 
 ## Extra environment variables that will be pass onto deployment pods
@@ -70,3 +72,6 @@ ingress:
     # - secretName: datarepo-example-tls
     #   hosts:
     #     - datarepo.example.com
+
+oidc:
+  b2cMetadataEndpoint: https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0/.well-known/openid-configuration


### PR DESCRIPTION
This PR does the following:
- Pulls in the new Apache proxy that we should be using now to allow talking to B2C
- Allows poking through the /oauth2 path to support auth hosted by TDR