### PR TITLE
DR-2504 Add support for defining an oauth client secret

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,8 +12,8 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.338
-appVersion: 1.334.0
+version: 0.0.339
+appVersion: 1.335.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application
 # appVersion: 1.16.0

--- a/charts/datarepo-api/templates/_helpers.tpl
+++ b/charts/datarepo-api/templates/_helpers.tpl
@@ -100,14 +100,14 @@ Generate existing key name in the secret
 {{- end -}}
 
 {{/*
-Generate exisiting key name in the secret for the synapse user
+Generate existing key name in the secret for the synapse user
 */}}
 {{- define "datarepo-api.secretKeySynapseUser" -}}
 {{ default (include "datarepo-api.fullname" .) .Values.existingSynapseUserSecretKey }}
 {{- end -}}
 
 {{/*
-Generate exisiting key name in the secret for the synapse password
+Generate existing key name in the secret for the synapse password
 */}}
 {{- define "datarepo-api.secretKeySynapsePassword" -}}
 {{ default (include "datarepo-api.fullname" .) .Values.existingSynapsePasswordSecretKey }}
@@ -157,4 +157,25 @@ Create repository image and imagetag with Terra Values.global.applicationVersion
 {{- else -}}
     {{ .Values.image.repository }}:{{ .Values.global.applicationVersion | default .Values.image.tag }}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Generate the secret name for OAuth
+*/}}
+{{- define "datarepo-api.secretNameOauth" -}}
+{{ default (include "datarepo-api.fullname" .) .Values.existingSecretNameOauth }}
+{{- end -}}
+
+{{/*
+Generate existing key name in the Oauth secret for the Oauth client secret
+*/}}
+{{- define "datarepo-api.secretKeyOauthClientSecret" -}}
+{{ default (include "datarepo-api.fullname" .) .Values.existingOauthClientSecretSecretKey }}
+{{- end -}}
+
+{{/*
+Check if the oauth client secret is defined
+*/}}
+{{- define "datarepo-api.hasOauthClientSecret" -}}
+{{ and .Values.existingSecretNameOauth .Values.existingOauthClientSecretSecretKey -}}
 {{- end -}}

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -1,4 +1,5 @@
 {{- $hasCredentials := include "datarepo-api.hasCredentials" . -}}
+{{- $hasOauthClientSecret := include "datarepo-api.hasOauthClientSecret" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -123,6 +124,13 @@ spec:
             secretKeyRef:
               name: {{ include "datarepo-api.secretNameAzure" . }}
               key: {{ include "datarepo-api.secretKeySynapsePassword" . }}
+        {{ end -}}
+        {{ if $hasOauthClientSecret -}}
+        - name: OIDC_CLIENTSECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "datarepo-api.secretNameOauth" . }}
+              key: {{ include "datarepo-api.secretKeyOauthClientSecret" . }}
         {{ end -}}
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/sa-key.json

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -78,6 +78,11 @@ existingSynapsePasswordSecretKey: ""
 existingSecretRBS: ""
 ## The key in the existing secret that stores the RBS service account credentials
 existingRBSSecretKey: ""
+## Specify an existing secret holding the Oauth service account credentials
+existingSecretNameOauth: ""
+## The key in the existing secret that stores the Oauth client secret
+existingOauthClientSecretSecretKey: ""
+
 # Sherlock is DSP's internal tool for tracking service deployments across all of terra and
 # extracting metric data from them. https://cloud.google.com/blog/products/devops-sre/using-the-four-keys-to-measure-your-devops-performance
 sherlock:


### PR DESCRIPTION
This simply adds an optional set of values that allows a deployment to specify an oauth client secret

I've deployed and tested manually both with and without the secret in my personal deployment to confirm that it works 