### PR TITLE
DR-2504 Manually bump the version of the UI chart

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.146
-appVersion: 0.123.0
+version: 0.0.147
+appVersion: 0.124.0
 keywords:
   - google
   - cloud


### PR DESCRIPTION
Looks like the version got bumped between when I opened and merged the PR.  Manually bumping to take the OIDC changes into account