### PR TITLE
DR-2562 Fix TCell config for prod

### DIFF
--- a/charts/datarepo-ui/Chart.yaml
+++ b/charts/datarepo-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: datarepo-ui
 description: A Helm chart to deploy datarepo ui server for Kubernetes
 type: application
-version: 0.0.148
-appVersion: 0.124.0
+version: 0.0.149
+appVersion: 0.125.0
 keywords:
   - google
   - cloud

--- a/charts/datarepo-ui/templates/configmap.yaml
+++ b/charts/datarepo-ui/templates/configmap.yaml
@@ -31,11 +31,11 @@ data:
 
         # add a Content-Security-Policy, with some variables to make formatting nice
         set $DEFAULT "default-src 'self'";
-        set $SCRIPT "script-src 'self' 'unsafe-inline' apis.google.com *.gstatic.com *.broadinstitute.org *.terra.bio *.envs-terra.bio jsagent.tcell.io";
+        set $SCRIPT "script-src 'self' 'unsafe-inline' apis.google.com *.gstatic.com *.broadinstitute.org *.terra.bio *.envs-terra.bio jsagent.tcell.io *.jsagent.tcell.insight.rapid7.com";
         set $STYLE "style-src 'self' 'unsafe-inline' fonts.googleapis.com";
         set $IMG "img-src 'self' data: *.googleusercontent.com *.terra.bio *.envs-terra.bio";
         set $FONT "font-src 'self' fonts.googleapis.com fonts.gstatic.com";
-        set $CONNECT "connect-src 'self' *.envs-terra.bio *.broadinstitute.org account.google.com *.googleapis.com";
+        set $CONNECT "connect-src 'self' *.envs-terra.bio *.broadinstitute.org account.google.com *.googleapis.com *.agent.tcell.insight.rapid7.com";
         set $FRAME "frame-src 'self' accounts.google.com";
         add_header Content-Security-Policy "${DEFAULT}; ${SCRIPT}; ${STYLE}; ${IMG}; ${FONT}; ${CONNECT}; ${FRAME}";
 

--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.32
-appVersion: 0.0.32
+version: 0.0.33
+appVersion: 0.0.33
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-# appVersion: 1.16.0
+
 keywords:
 - google
 - cloud

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -191,3 +191,19 @@ data:
   oauth2conf: |-
     OAuth2TokenVerify metadata {{ .Values.oidc.b2cMetadataEndpoint }} metadata.ssl_verify=true&verify.iat=skip
     OAuth2TokenVerify introspect http://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.iat=skip
+
+  {{- if .Values.tcell.enabled }}
+  tcellconf: |-
+    {
+      "version": 1,
+      "applications": [
+        {
+          "tcell_api_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "tcell_input_url": "https://us.input.tcell.insight.rapid7.com/api/v1",
+          "js_agent_api_base_url": "https://us.agent.tcell.insight.rapid7.com/api/v1",
+          "host_identifier":"{{ .Values.tcell.hostIdentifier }}",
+          "logging_options":{"enabled":true,"level":"INFO","filename":"mytcell.log"}
+        }
+      ]
+    }
+  {{- end }}

--- a/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
+++ b/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
@@ -53,10 +53,24 @@ spec:
           value: "{{ $value }}"
         {{- end }}
         {{- end }}
+        {{- if .Values.tcell.enabled }}
+        - name: TCELL_AGENT_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.tcell.tcellSecret }}
+              key: app-id
+        - name: TCELL_AGENT_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.tcell.tcellSecret }}
+              key: api-key
+        - name: ENABLE_TCELL
+          value: 'yes'
+        {{- end }}
         volumeMounts:
-          {{- if or .Values.tcell.tcellSecret .Values.tcell.tcellSecretKey }}
+          {{- if .Values.tcell.enabled }}
           - mountPath: /etc/apache2/tcell_agent.config
-            name: tcell
+            name: tcellconf
             subPath: tcell_agent.config
           {{- end }}
           - mountPath: /etc/apache2/sites-available/site.conf
@@ -66,14 +80,6 @@ spec:
             name: oauth2conf
             subPath: oauth2.conf
       volumes:
-        {{- if or .Values.tcell.tcellSecret .Values.tcell.tcellSecretKey }}
-        - name: tcell
-          secret:
-            secretName: {{ .Values.tcell.tcellSecret }}
-            items:
-            - key: {{ .Values.tcell.tcellSecretKey }}
-              path: tcell_agent.config
-        {{- end }}
         - name: siteconf
           configMap:
             name: {{ template "oidc-proxy.fullname" . }}
@@ -86,6 +92,14 @@ spec:
             items:
               - key: oauth2conf
                 path: oauth2.conf
+        {{- if .Values.tcell.enabled }}
+        - name: tcellconf
+          configMap:
+            name: {{ template "oidc-proxy.fullname" . }}
+            items:
+              - key: tcellconf
+                path: tcell_agent.config
+        {{- end }}
 
 {{- if .Values.resources }}
         resources:

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -16,8 +16,10 @@ env: {}
 
 ## TCELL
 tcell:
+  enabled: false
+  ## Note: the secret must contain an app-id value and an api-key value
   tcellSecret: ""
-  tcellSecretKey: ""
+  host_identifier: ""
 
 ## Pod annotations
 podAnnotations: {}


### PR DESCRIPTION
We recently updated the apache proxy image and with that came a new version of the TCell agent.  This fix makes it so that we should be able to launch with TCell enabled with the next monolith release.

TLDR: this changes the format of the config JSON and pulls down the TCell API key into from a secret now (rather than the whole config)

I also fixed the UI proxy so that the javascript agent gets loaded too