### PR TITLE
[DR-2583] Allow select ga4gh endpoints to be unauthed

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.33
-appVersion: 0.0.33
+version: 0.0.34
+appVersion: 0.0.34
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -142,6 +142,13 @@ data:
         <Location ${PROXY_PATH3}>
             RewriteEngine Off
 
+            # DRS OPTIONS endpoints can be accessed without any authentication.
+            # DRS POST endpoints typically use Passport auth, so the user does not need to pass through B2C login.
+            <Limit OPTIONS POST>
+                ${AUTH_TYPE}
+                ${AUTH_REQUIRE}
+            </Limit>
+
             ${AUTH_TYPE3}
             <RequireAll>
               <RequireAll>
@@ -168,28 +175,10 @@ data:
         </Location>
 
         # DRS GetServiceInfo endpoint can be accessed without any authentication.
-        # TODO: do we benefit from a more aggressive regex here?
         <Location ${PROXY_PATH3}/drs/v1/service-info>
             ${AUTH_TYPE}
             ${AUTH_REQUIRE}
         </Location>
-
-        # DRS OptionsObject endpoint can be accessed without any authentication.
-        # DRS PostObject endpoint will use Passport auth, so the user does not need to pass through B2C login.
-        <LocationMatch "^${PROXY_PATH3}/drs/v1/objects/([^\/]+)$">
-            <Limit OPTIONS POST>
-                ${AUTH_TYPE}
-                ${AUTH_REQUIRE}
-            </Limit>
-        </LocationMatch>
-
-        # DRS PostAccessUrl endpoint will use Passport auth, so the user does not need to pass through B2C login.
-        <LocationMatch "^${PROXY_PATH3}/drs/v1/objects/([^\/]+)/access/([^\/]+)$">
-            <Limit POST>
-                ${AUTH_TYPE}
-                ${AUTH_REQUIRE}
-            </Limit>
-        </LocationMatch>
 
         # Bigquery redirect logic.  Note: we are not authorizing the request since that is handled by the bigquery API
         # This is here to work around CORS rules that are enforced by the BigQuery APIs.  This makes it so that ours are

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -140,14 +140,6 @@ data:
         </Location>
 
         <Location ${PROXY_PATH3}>
-            RewriteEngine On
-            RewriteCond %{REQUEST_METHOD} OPTIONS
-            RewriteRule ^(.*)$ $1 [R=204,L]
-
-            <Limit OPTIONS>
-                Require all granted
-            </Limit>
-
             ${AUTH_TYPE3}
             <RequireAll>
               <RequireAll>
@@ -172,6 +164,30 @@ data:
 
             ${FILTER3}
         </Location>
+
+        # DRS GetServiceInfo endpoint can be accessed without any authentication.
+        # TODO: do we benefit from a more aggressive regex here?
+        <Location ${PROXY_PATH3}/drs/v1/service-info>
+            ${AUTH_TYPE}
+            ${AUTH_REQUIRE}
+        </Location>
+
+        # DRS OptionsObject endpoint can be accessed without any authentication.
+        # DRS PostObject endpoint will use Passport auth, so the user does not need to pass through B2C login.
+        <LocationMatch "^${PROXY_PATH3}/drs/v1/objects/([^\/]+)$">
+            <Limit OPTIONS POST>
+                ${AUTH_TYPE}
+                ${AUTH_REQUIRE}
+            </Limit>
+        </LocationMatch>
+
+        # DRS PostAccessUrl endpoint will use Passport auth, so the user does not need to pass through B2C login.
+        <LocationMatch "^${PROXY_PATH3}/drs/v1/objects/([^\/]+)/access/([^\/]+)$">
+            <Limit POST>
+                ${AUTH_TYPE}
+                ${AUTH_REQUIRE}
+            </Limit>
+        </LocationMatch>
 
         # Bigquery redirect logic.  Note: we are not authorizing the request since that is handled by the bigquery API
         # This is here to work around CORS rules that are enforced by the BigQuery APIs.  This makes it so that ours are

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -140,6 +140,8 @@ data:
         </Location>
 
         <Location ${PROXY_PATH3}>
+            RewriteEngine Off
+
             ${AUTH_TYPE3}
             <RequireAll>
               <RequireAll>


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2583

**Objectives**

Allow select ga4gh endpoints to be accessible without authorization.

- [GetServiceInfo](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/GetServiceInfo)
- [OptionsObject](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/OptionsObject)
- [PostObject](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/PostObject)
- [PostAccessUrl](https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService/PostAccessUrl)

Requirements for accessing all other endpoints should remain unchanged.

**Verification**

These configurations have been deployed to my dev environment: https://jade-ok.datarepo-dev.broadinstitute.org/swagger-ui.html#/DataRepositoryService

Using the following resources:
- [Dataset](https://jade-ok.datarepo-dev.broadinstitute.org/datasets/79ef03d8-161a-4143-bb09-c00cf7c11570) with PHS ID "phs000710"
- [Snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/6510b127-c226-46a1-ac12-c5f2383cbd08) with consent code "c99", its row has a field with DRS object ID `v1_6510b127-c226-46a1-ac12-c5f2383cbd08_935baf22-8428-4cd1-b229-9e2a9fb2c2d7`
- [Snapshot](https://jade-ok.datarepo-dev.broadinstitute.org/snapshots/0933cc3c-54c7-4b03-a16b-ee4cdeec8263) with no consent code, its row has a field with DRS object ID `v1_0933cc3c-54c7-4b03-a16b-ee4cdeec8263_935baf22-8428-4cd1-b229-9e2a9fb2c2d7`
- Passport associated with [Broadtestuser115](https://docs.google.com/spreadsheets/d/13jaYEFeQgUV0j2QqfwOCjw1h9APrrAxs5xbH60BW6oo/edit?usp=sharing) - decodes to show PHS ID "phs000710" and consent code "c99"

I hit all of the DRS endpoints:
- When unauthorized, Apache blocks calls to GetObject and GetAccessUrl with a "401 Unauthorized" response.  Remaining endpoints can be called successfully.
- When authorized, can call all endpoints.

I should have added `DataRepoAdmins@dev.test.firecloud.org` to all necessary resources in case anyone would like to play around!

**Development Thoughts**

- When a path matches multiple `<Location>` blocks, their directives are merged together with the last match winning in the event of a duplicate (found this helpful: https://serverfault.com/a/391488).  So I didn't set ProxyPass, ProxyPassReverse in my additions with the thought that they'd pull from the earlier match.
- ~~Paths to our DRS endpoints nest within each other so I wanted to be precise in overriding access requirements.~~ ETA: not a dealbreaker to have this precision, but I added a note in comments.
- The same path can have different access requirements depending on the HTTP method used.
- ~~(Maybe some of this points to value in reorganizing our endpoints?)~~ ETA: not within our control, defined by external specification.
