### PR TITLE
[DDO-2122] Bump BEE usage of ephemeral postgres chart

### DIFF
--- a/charts/datarepo/Chart.lock
+++ b/charts/datarepo/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 0.1.4
 - name: postgres
   repository: https://terra-helm.storage.googleapis.com/
-  version: 0.26.0
-digest: sha256:c750edf9bf6f578702028c8663732107eb8f7fc98d776e03110dcd7fa2e0c317
-generated: "2022-06-08T18:48:54.538020696Z"
+  version: 0.30.0
+digest: sha256:e003aaba7e0cf13845ceda792b521124e18da69b1f1f47a3b01cd9b8dc860d31
+generated: "2022-06-08T18:57:24.123404-04:00"

--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -52,6 +52,6 @@ dependencies:
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: de-elasticsearch.enabled
 - name: postgres
-  version: 0.26.0
+  version: 0.30.0
   repository: https://terra-helm.storage.googleapis.com/
   condition: postgres.enabled


### PR DESCRIPTION
Cleanup from getting DUOS working in BEEs--new version of the postgres chart needs to be bumped here manually. There's some downstream impacts [here](https://github.com/broadinstitute/terra-helmfile/blob/master/values/app/datarepo/bee.yaml.gotmpl#L78) I'll have to tweak once this is merged before we can use the new `datarepo`, but that's over on our side and, like this PR, only impacts BEEs.