### PR TITLE
DDO-2153 Prefix PSPs with namespace in BEEs

### DIFF
--- a/charts/datarepo-api/templates/_helpers.tpl
+++ b/charts/datarepo-api/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Name for the psp used by deployments in this chart
+*/}}
+{{- define "datarepo-api.psp.name" -}}
+{{- if .Values.rbac.namespacePrefix -}}
+{{ .Release.Namespace }}-{{ include "datarepo-api.fullname" . }}-pod-running-policy
+{{- else -}}
+{{ include "datarepo-api.fullname" . }}-pod-running-policy
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "datarepo-api.chart" -}}

--- a/charts/datarepo-api/templates/pod-running-policy.yaml
+++ b/charts/datarepo-api/templates/pod-running-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ include "datarepo-api.fullname" . }}-pod-running-policy"
+  name: {{ include "datarepo-api.psp.name" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     name: podsecuritypolicy

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -11,5 +11,5 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ["use"]
   resourceNames:
-    - "{{ include "datarepo-api.fullname" . }}-pod-running-policy"
+    - {{ include "datarepo-api.psp.name" . | quote }}
 {{- end }}

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -44,6 +44,8 @@ serviceAccount:
 rbac:
   # Specifies whether a psp should be created
   create: false
+  # If true, prefix the psp with the release's namespace. (Used to prevent conflicts in BEEs)
+  namespacePrefix: false
 service:
   port: 8080
   type: ClusterIP

--- a/charts/datarepo-ui/templates/_helpers.tpl
+++ b/charts/datarepo-ui/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Name for the psp used by deployments in this chart
+*/}}
+{{- define "datarepo-ui.psp.name" -}}
+{{- if .Values.rbac.namespacePrefix -}}
+{{ .Release.Namespace }}-{{ include "datarepo-ui.fullname" . }}-pod-running-policy
+{{- else -}}
+{{ include "datarepo-ui.fullname" . }}-pod-running-policy
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "datarepo-ui.chart" -}}

--- a/charts/datarepo-ui/templates/pod-running-policy.yaml
+++ b/charts/datarepo-ui/templates/pod-running-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ include "datarepo-ui.fullname" . }}-pod-running-policy"
+  name: {{ include "datarepo-api.psp.name" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     name: podsecuritypolicy

--- a/charts/datarepo-ui/templates/pod-running-policy.yaml
+++ b/charts/datarepo-ui/templates/pod-running-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "datarepo-api.psp.name" . | quote }}
+  name: {{ include "datarepo-ui.psp.name" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     name: podsecuritypolicy

--- a/charts/datarepo-ui/templates/role.yaml
+++ b/charts/datarepo-ui/templates/role.yaml
@@ -11,5 +11,5 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ["use"]
   resourceNames:
-    - "{{ include "datarepo-ui.fullname" . }}-pod-running-policy"
+    - {{ include "datarepo-ui.psp.name" . | quote }}
 {{- end }}

--- a/charts/datarepo-ui/values.yaml
+++ b/charts/datarepo-ui/values.yaml
@@ -44,6 +44,8 @@ serviceAccount:
 rbac:
   # Specifies whether a psp should be created
   create: true
+  # If true, prefix the psp with the release's namespace. (Used to prevent conflicts in BEEs)
+  namespacePrefix: false
 service:
   type: ClusterIP
   port: 8080

--- a/charts/oidc-proxy/templates/_helpers.tpl
+++ b/charts/oidc-proxy/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Name for the psp used by deployments in this chart
+*/}}
+{{- define "oidc-proxy.psp.name" -}}
+{{- if .Values.rbac.namespacePrefix -}}
+{{ .Release.Namespace }}-{{ include "oidc-proxy.fullname" . }}-pod-running-policy
+{{- else -}}
+{{ include "oidc-proxy.fullname" . }}-pod-running-policy
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "oidc-proxy.chart" -}}

--- a/charts/oidc-proxy/templates/pod-running-policy.yaml
+++ b/charts/oidc-proxy/templates/pod-running-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: "{{ include "oidc-proxy.fullname" . }}-oidc-pod-running-policy"
+  name: {{ include "oidc-proxy.psp.name" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "oidc-proxy.labels" . | nindent 4 }}

--- a/charts/oidc-proxy/templates/role.yaml
+++ b/charts/oidc-proxy/templates/role.yaml
@@ -11,5 +11,5 @@ rules:
   resources: ['podsecuritypolicies']
   verbs: ["use"]
   resourceNames:
-    - "{{ include "oidc-proxy.fullname" . }}-oidc-pod-running-policy"
+    - {{ include "oidc-proxy.psp.name" . | quote }}
 {{- end }}

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -53,6 +53,8 @@ serviceAccount:
 rbac:
   # Specifies whether a psp should be created
   create: false
+  # If true, prefix the psp with the release's namespace. (Used to prevent conflicts in BEEs)
+  namespacePrefix: false
 
 service:
   type: NodePort


### PR DESCRIPTION
We're running into cross-namespace conflicts with TDR's PodSecurityPolicies in BEEs:
![Screen Shot 2022-08-02 at 4 02 06 PM](https://user-images.githubusercontent.com/60902147/182471517-174bdbd7-775b-4cd3-a8f5-eda67e1196b9.png)

This is because unlike other types of K8s resources, PSPs are cluster-level and not scoped to a namespace. Every BEE is sharing (and attempting to manage) the same PSP object.

This PR addresses the issue by adding a new Helm chart value, `rbac.namespacePrefix`, to the `datarepo-api`, `datarepo-ui`, and `oidc-proxy` Helm charts. When set to `true`, the names of the PSPs in these charts will be prefixed with the release's namespace. This new value defaults to `false` and will only be enabled in BEEs.
