### PR TITLE
Allow JWTs from the generic Azure tenant

### DIFF
--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -210,6 +210,7 @@ data:
     {{- range .Values.ingress.b2cMetadataEndpoints }}
     OAuth2TokenVerify metadata {{ . }} metadata.ssl_verify=true&verify.iat=skip
     {{- end}}
+    OAuth2TokenVerify metadata https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration metadata.ssl_verify=true&verify.exp=required&verify.iat=skip
     OAuth2TokenVerify introspect http://127.0.0.1/introspect/ introspect.ssl_verify=false&verify.iat=skip
 
   {{- if .Values.tcell.enabled }}


### PR DESCRIPTION
So that we can work with Azure Pet Service Accounts (that don't come from B2C)

This is config that makes it so that the proxy lets these through to TDR