### PR TITLE
DDO-2562 Support Secrets Manager in AKS - Decouple RBAC and PSP

### DIFF
--- a/charts/install-secrets-manager/Chart.yaml
+++ b/charts/install-secrets-manager/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/install-secrets-manager/templates/role.yaml
+++ b/charts/install-secrets-manager/templates/role.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.rbac.create -}}
+{{- if .Values.podSecurityPolicy.create -}}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -21,6 +22,7 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
+{{- end }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,11 +33,13 @@ metadata:
     app: {{ .Chart.Name }}
     {{- include "install-secrets-manager.labels" . | nindent 4 }}
 rules:
+{{- if .Values.podSecurityPolicy.create }}
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs: ["use"]
   resourceNames:
     - "{{ include "install-secrets-manager.fullname" . }}-pod-running-policy"
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/charts/install-secrets-manager/values.yaml
+++ b/charts/install-secrets-manager/values.yaml
@@ -18,7 +18,7 @@ rbac:
 
 podSecurityPolicy:
  # defaulting to true for backwards compatibility with old versions where PSP creation was coupled to
- # rbac.create 
+ # rbac.create
   create: true
 
 ## create new secrets

--- a/charts/install-secrets-manager/values.yaml
+++ b/charts/install-secrets-manager/values.yaml
@@ -16,6 +16,11 @@ rbac:
   # Specifies whether a psp should be created
   create: false
 
+podSecurityPolicy:
+ # defaulting to true for backwards compatibility with old versions where PSP creation was coupled to
+ # rbac.create 
+  create: true
+
 ## create new secrets
 secretsgeneric:
   roleId: ""


### PR DESCRIPTION
I'm trying to run secrets manager on an aks cluster. PSPs are deprecated in AKS but this chart couples psps to other rbac resources like clusterRoles etc which are needed. This PR aims to decouple  them in a backwards compatible manner