### PR TITLE
No-op Version Bump to re-trigger chart publishing

### DIFF
--- a/charts/install-secrets-manager/Chart.yaml
+++ b/charts/install-secrets-manager/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.


### PR DESCRIPTION
No-op version bump to re-trigger publishing of my previous change that had due to a bad GH token