### PR TITLE
DR-2885 - Chart Releaser Action: try new version and github token

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -29,9 +29,9 @@ jobs:
           helm repo update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_TOKEN: "${{ secrets.BROADBOT_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
 
       - name: "Notify Slack"

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -43,9 +43,9 @@ jobs:
           helm repo update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_TOKEN: "${{ secrets.BROADBOT_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
 
       - name: Pause between chart release and creation of new umbrella chart


### PR DESCRIPTION
[Updating to use BROADBOT_TOKEN did not appear to work. ](https://github.com/broadinstitute/datarepo-helm/pull/230)

Looking at the [documentation](https://github.com/helm/chart-releaser-action#environment-variables) for helm/chart-releaser-action, it appears that using GITHUB_TOKEN instead should work. I also bumped to the latest version of the action because hopefully that should best reflect what the documentation suggests. 