### PR TITLE
DR-2889: Upgrade Github actions due to Node 12 Deprecation 

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -1,7 +1,11 @@
 name: Release helm charts
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       notify-slack:

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -37,14 +37,12 @@ jobs:
           helm repo add terra-helm https://terra-helm.storage.googleapis.com
           helm repo update
 
-      # - name: Run chart-releaser
-      #   uses: helm/chart-releaser-action@v1.5.0
-      #   env:
-      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      #     CR_SKIP_EXISTING: "true"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"
 
-      - name: "test"
-        run: echo ${{ github.event_name }}
       - name: "Notify Slack"
         if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.15.0

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -2,7 +2,11 @@ name: Release helm charts
 
 on:
   workflow_dispatch: {}
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
 
 jobs:
   release_chart:
@@ -38,7 +42,7 @@ jobs:
       - name: "test"
         run: echo ${{ github.event_name }}
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
     inputs:
       notify-slack:
-        default: true
+        default: false
         type: boolean
 
 jobs:

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -29,12 +29,14 @@ jobs:
           helm repo add terra-helm https://terra-helm.storage.googleapis.com
           helm repo update
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: "true"
+      # - name: Run chart-releaser
+      #   uses: helm/chart-releaser-action@v1.5.0
+      #   env:
+      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      #     CR_SKIP_EXISTING: "true"
 
+      - name: "test"
+        run: echo ${{ github.event_name }}
       - name: "Notify Slack"
         if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
         uses: broadinstitute/action-slack@v3.15.0

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -36,8 +36,8 @@ jobs:
           CR_SKIP_EXISTING: "true"
 
       - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -2,6 +2,7 @@ name: Release helm charts
 
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   release_chart:

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -45,48 +45,48 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: ${{ matrix.repo }}
 
-      # - name: "Find latest version chart version"
-      #   id: chartversion
-      #   run: |
-      #     for i in $(echo ${{ env.charts }})
-      #     do
-      #       CHART_VERSION=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/$i/Chart.yaml 'version')
-      #       echo "New $i version $CHART_VERSION"
-      #       echo "::set-output name=$i-version::$CHART_VERSION"
+      - name: "Find latest version chart version"
+        id: chartversion
+        run: |
+          for i in $(echo ${{ env.charts }})
+          do
+            CHART_VERSION=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/$i/Chart.yaml 'version')
+            echo "New $i version $CHART_VERSION"
+            echo "::set-output name=$i-version::$CHART_VERSION"
             
-      #     done
+          done
 
-      # - name: "Find and replace datarepo-api chartVersion version in integration action"
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_api_chart_version" ${{ steps.chartversion.outputs.datarepo-api-version }}
+      - name: "Find and replace datarepo-api chartVersion version in integration action"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_api_chart_version" ${{ steps.chartversion.outputs.datarepo-api-version }}
 
-      # - name: "Find and replace datarepo-ui chartVersion version in integration action"
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_ui_chart_version" ${{ steps.chartversion.outputs.datarepo-ui-version }}
+      - name: "Find and replace datarepo-ui chartVersion version in integration action"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_ui_chart_version" ${{ steps.chartversion.outputs.datarepo-ui-version }}
 
-      # - name: "Find and replace gcloud-sqlproxy chartVersion version in integration action"
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_gcloud_sqlproxy_chart_version" ${{ steps.chartversion.outputs.gcloud-sqlproxy-version }}
+      - name: "Find and replace gcloud-sqlproxy chartVersion version in integration action"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_gcloud_sqlproxy_chart_version" ${{ steps.chartversion.outputs.gcloud-sqlproxy-version }}
 
-      # - name: "Find and replace oidc-proxy chartVersion version in integration action"
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_oidc_proxy_chart_version" ${{ steps.chartversion.outputs.oidc-proxy-version }}
+      - name: "Find and replace oidc-proxy chartVersion version in integration action"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_oidc_proxy_chart_version" ${{ steps.chartversion.outputs.oidc-proxy-version }}
 
-      # - name: print new chart
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
+      - name: print new chart
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
 
-      # - name: "[${{ matrix.repo }}] Merge multi chart version update"
-      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-      #   env:
-      #     COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
-      #     GITHUB_REPO: ${{ matrix.repo }}
-      #     SWITCH_DIRECTORIES: "true"
+      - name: "[${{ matrix.repo }}] Merge multi chart version update"
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        env:
+          COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
+          GITHUB_REPO: ${{ matrix.repo }}
+          SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
         if: ${{ inputs.notify-slack && always() }}

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -4,6 +4,7 @@ env:
 
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   indivdual_chart_promotion:

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -3,8 +3,16 @@ env:
   charts: gcloud-sqlproxy datarepo-api datarepo-ui oidc-proxy
 
 on:
-  workflow_dispatch: {}
-  workflow_call: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: false
+        type: boolean
 
 jobs:
   indivdual_chart_promotion:
@@ -81,7 +89,7 @@ jobs:
       #     SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -81,8 +81,8 @@ jobs:
           SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -37,48 +37,48 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN }}
           path: ${{ matrix.repo }}
 
-      - name: "Find latest version chart version"
-        id: chartversion
-        run: |
-          for i in $(echo ${{ env.charts }})
-          do
-            CHART_VERSION=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/$i/Chart.yaml 'version')
-            echo "New $i version $CHART_VERSION"
-            echo "::set-output name=$i-version::$CHART_VERSION"
+      # - name: "Find latest version chart version"
+      #   id: chartversion
+      #   run: |
+      #     for i in $(echo ${{ env.charts }})
+      #     do
+      #       CHART_VERSION=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/$i/Chart.yaml 'version')
+      #       echo "New $i version $CHART_VERSION"
+      #       echo "::set-output name=$i-version::$CHART_VERSION"
             
-          done
+      #     done
 
-      - name: "Find and replace datarepo-api chartVersion version in integration action"
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_api_chart_version" ${{ steps.chartversion.outputs.datarepo-api-version }}
+      # - name: "Find and replace datarepo-api chartVersion version in integration action"
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_api_chart_version" ${{ steps.chartversion.outputs.datarepo-api-version }}
 
-      - name: "Find and replace datarepo-ui chartVersion version in integration action"
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_ui_chart_version" ${{ steps.chartversion.outputs.datarepo-ui-version }}
+      # - name: "Find and replace datarepo-ui chartVersion version in integration action"
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_datarepo_ui_chart_version" ${{ steps.chartversion.outputs.datarepo-ui-version }}
 
-      - name: "Find and replace gcloud-sqlproxy chartVersion version in integration action"
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_gcloud_sqlproxy_chart_version" ${{ steps.chartversion.outputs.gcloud-sqlproxy-version }}
+      # - name: "Find and replace gcloud-sqlproxy chartVersion version in integration action"
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_gcloud_sqlproxy_chart_version" ${{ steps.chartversion.outputs.gcloud-sqlproxy-version }}
 
-      - name: "Find and replace oidc-proxy chartVersion version in integration action"
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_oidc_proxy_chart_version" ${{ steps.chartversion.outputs.oidc-proxy-version }}
+      # - name: "Find and replace oidc-proxy chartVersion version in integration action"
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq w -i ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }} "jobs.${{ matrix.jobname }}.steps.(name==Deploy to cluster with Helm).with.helm_oidc_proxy_chart_version" ${{ steps.chartversion.outputs.oidc-proxy-version }}
 
-      - name: print new chart
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
+      # - name: print new chart
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
 
-      - name: "[${{ matrix.repo }}] Merge multi chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-        env:
-          COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
-          GITHUB_REPO: ${{ matrix.repo }}
-          SWITCH_DIRECTORIES: "true"
+      # - name: "[${{ matrix.repo }}] Merge multi chart version update"
+      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+      #   env:
+      #     COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
+      #     GITHUB_REPO: ${{ matrix.repo }}
+      #     SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
         if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: "Notify Slack"
         if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: v3.4.0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -1,6 +1,7 @@
 name: Create chart Datarepo chart
 
 on:
+  workflow_call: {}
   workflow_dispatch: {}
   push:
     branches:

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -51,26 +51,26 @@ jobs:
           helm repo add terra-helm https://terra-helm.storage.googleapis.com
           helm repo update
 
-      # - name: Run chart-releaser
-      #   uses: helm/chart-releaser-action@v1.5.0
-      #   env:
-      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      #     CR_SKIP_EXISTING: "true"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"
 
-      # - name: Pause between chart release and creation of new umbrella chart
-      #   id: wait
-      #   run: |
-      #     sleep 30
+      - name: Pause between chart release and creation of new umbrella chart
+        id: wait
+        run: |
+          sleep 30
 
-      # - name: "Create new umbrella chart"
-      #   uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
+      - name: "Create new umbrella chart"
+        uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
 
-      # - name: "[datarepo-helm] Merge in changes to umbrella chart"
-      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-      #   env:
-      #     COMMIT_MESSAGE: "Datarepo umbrella chart update"
-      #     GITHUB_REPO: datarepo-helm
-      #     MERGE_BRANCH: master
+      - name: "[datarepo-helm] Merge in changes to umbrella chart"
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        env:
+          COMMIT_MESSAGE: "Datarepo umbrella chart update"
+          GITHUB_REPO: datarepo-helm
+          MERGE_BRANCH: master
 
       - name: "Notify Slack"
         if: ${{ (github.event_name == 'push' && always()) || (inputs.notify-slack && always()) }} # workflow_call has own slack notification

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -65,8 +65,8 @@ jobs:
           MERGE_BRANCH: master
 
       - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -43,26 +43,26 @@ jobs:
           helm repo add terra-helm https://terra-helm.storage.googleapis.com
           helm repo update
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_SKIP_EXISTING: "true"
+      # - name: Run chart-releaser
+      #   uses: helm/chart-releaser-action@v1.5.0
+      #   env:
+      #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      #     CR_SKIP_EXISTING: "true"
 
-      - name: Pause between chart release and creation of new umbrella chart
-        id: wait
-        run: |
-          sleep 30
+      # - name: Pause between chart release and creation of new umbrella chart
+      #   id: wait
+      #   run: |
+      #     sleep 30
 
-      - name: "Create new umbrella chart"
-        uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
+      # - name: "Create new umbrella chart"
+      #   uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
 
-      - name: "[datarepo-helm] Merge in changes to umbrella chart"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-        env:
-          COMMIT_MESSAGE: "Datarepo umbrella chart update"
-          GITHUB_REPO: datarepo-helm
-          MERGE_BRANCH: master
+      # - name: "[datarepo-helm] Merge in changes to umbrella chart"
+      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+      #   env:
+      #     COMMIT_MESSAGE: "Datarepo umbrella chart update"
+      #     GITHUB_REPO: datarepo-helm
+      #     MERGE_BRANCH: master
 
       - name: "Notify Slack"
         if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -1,8 +1,16 @@
 name: Create chart Datarepo chart
 
 on:
-  workflow_call: {}
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: false
+        type: boolean
   push:
     branches:
       - master
@@ -65,7 +73,7 @@ jobs:
       #     MERGE_BRANCH: master
 
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ (github.event_name == 'push' && always()) || (inputs.notify-slack && always()) }} # workflow_call has own slack notification
         uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releasedrumbrella.yaml
+++ b/.github/workflows/releasedrumbrella.yaml
@@ -21,25 +21,27 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.BROADBOT_TOKEN }}
           fetch-depth: 0   # otherwise, you will failed to push refs to dest repo
-
-      - name: Trigger action to run chart-releaser for  datarepo umbrella
-        uses: broadinstitute/workflow-dispatch@v1.1
-        with:
-          workflow: Release helm charts
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Trigger action to run alpha chart promotion
-        uses: broadinstitute/workflow-dispatch@v1.1
-        with:
-          workflow: Alpha Chart Promotion
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
-      - name: Trigger action to run alpha chart promotion
-        uses: broadinstitute/workflow-dispatch@v1.1
-        with:
-          workflow: Integration Chart Promotion
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
+  release_umbrella_helm_charts:
+    needs: release_new_umbrella_dr
+    uses: ./.github/workflows/chart-releaser.yaml
+    secrets: inherit
+  alpha_chart_promotion:
+    needs: release_new_umbrella_dr
+    uses: ./.github/workflows/terraAlphaChartBump.yaml
+    secrets: inherit
+  integration_chart_promotion:
+    needs: release_new_umbrella_dr
+    uses: ./.github/workflows/integrationChartBump.yaml
+    secrets: inherit
+  notify_slack:
+    needs:
+      - release_new_umbrella_dr
+      - release_umbrella_helm_charts
+      - alpha_chart_promotion
+      - integration_chart_promotion
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
       - name: "Notify Slack"
         if: always()
         uses: broadinstitute/action-slack@v3.8.0

--- a/.github/workflows/releasedrumbrella.yaml
+++ b/.github/workflows/releasedrumbrella.yaml
@@ -43,8 +43,7 @@ jobs:
     if: always()
     steps:
       - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/releasenondr.yaml
+++ b/.github/workflows/releasenondr.yaml
@@ -30,8 +30,6 @@ jobs:
   release_helm_charts:
     needs: release_non_dr_chart
     uses: ./.github/workflows/chart-releaser.yaml
-    with:
-      notify-slack: false
     secrets: inherit
 
   notify_slack:

--- a/.github/workflows/releasenondr.yaml
+++ b/.github/workflows/releasenondr.yaml
@@ -30,7 +30,10 @@ jobs:
   release_helm_charts:
     needs: release_non_dr_chart
     uses: ./.github/workflows/chart-releaser.yaml
+    with:
+      notify-slack: false
     secrets: inherit
+
   notify_slack:
     needs:
       - release_non_dr_chart

--- a/.github/workflows/releasenondr.yaml
+++ b/.github/workflows/releasenondr.yaml
@@ -27,15 +27,18 @@ jobs:
           persist-credentials: true
           fetch-depth: 0   # otherwise, you will failed to push refs to dest repo
           token: "${{ secrets.BROADBOT_TOKEN }}"
-
-      - name: Trigger action to run chart-releaser
-        uses: broadinstitute/workflow-dispatch@v1
-        with:
-          workflow: Release helm charts
-          token: ${{ secrets.BROADBOT_TOKEN }}
-
+  release_helm_charts:
+    needs: release_non_dr_chart
+    uses: ./.github/workflows/chart-releaser.yaml
+    secrets: inherit
+  notify_slack:
+    needs:
+      - release_non_dr_chart
+      - release_helm_charts
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
       - name: "Notify Slack"
-        if: always()
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releasenondr.yaml
+++ b/.github/workflows/releasenondr.yaml
@@ -39,7 +39,7 @@ jobs:
     if: always()
     steps:
       - name: "Notify Slack"
-        uses: broadinstitute/action-slack@v3.8.0
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -2,6 +2,7 @@
 name: Alpha Chart Promotion
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   alpha_chart_promotion:

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -27,16 +27,16 @@ jobs:
         run: |
           echo "::set-output name=version::$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/datarepo/Chart.yaml version)"
 
-      - name: "Find and replace Datarepo chartVersion version in alpha action"
-        uses: docker://mikefarah/yq:3
-        with:
-          args: yq w -i jade-data-repo/.github/workflows/alpha-promotion.yaml env.chartVersion ${{ steps.chartversion.outputs.version }}
+      # - name: "Find and replace Datarepo chartVersion version in alpha action"
+      #   uses: docker://mikefarah/yq:3
+      #   with:
+      #     args: yq w -i jade-data-repo/.github/workflows/alpha-promotion.yaml env.chartVersion ${{ steps.chartversion.outputs.version }}
 
-      - name: "[jade-data-repo] Merge Changes"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-        env:
-          COMMIT_MESSAGE: "Datarepo chart version update: ${{ steps.chartversion.outputs.version }}"
-          SWITCH_DIRECTORIES: "true"
+      # - name: "[jade-data-repo] Merge Changes"
+      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+      #   env:
+      #     COMMIT_MESSAGE: "Datarepo chart version update: ${{ steps.chartversion.outputs.version }}"
+      #     SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
         if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -39,8 +39,8 @@ jobs:
           SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.8.0
+        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -1,8 +1,16 @@
 
 name: Alpha Chart Promotion
 on:
-  workflow_dispatch: {}
-  workflow_call: {}
+  workflow_dispatch:
+    inputs:
+      notify-slack:
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      notify-slack:
+        default: false
+        type: boolean
 
 jobs:
   alpha_chart_promotion:
@@ -39,7 +47,7 @@ jobs:
       #     SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
-        if: ${{ github.event_name != 'workflow_call' && always() }} # workflow_call has own slack notification
+        if: ${{ inputs.notify-slack && always() }}
         uses: broadinstitute/action-slack@v3.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -35,16 +35,16 @@ jobs:
         run: |
           echo "::set-output name=version::$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/datarepo/Chart.yaml version)"
 
-      # - name: "Find and replace Datarepo chartVersion version in alpha action"
-      #   uses: docker://mikefarah/yq:3
-      #   with:
-      #     args: yq w -i jade-data-repo/.github/workflows/alpha-promotion.yaml env.chartVersion ${{ steps.chartversion.outputs.version }}
+      - name: "Find and replace Datarepo chartVersion version in alpha action"
+        uses: docker://mikefarah/yq:3
+        with:
+          args: yq w -i jade-data-repo/.github/workflows/alpha-promotion.yaml env.chartVersion ${{ steps.chartversion.outputs.version }}
 
-      # - name: "[jade-data-repo] Merge Changes"
-      #   uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
-      #   env:
-      #     COMMIT_MESSAGE: "Datarepo chart version update: ${{ steps.chartversion.outputs.version }}"
-      #     SWITCH_DIRECTORIES: "true"
+      - name: "[jade-data-repo] Merge Changes"
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        env:
+          COMMIT_MESSAGE: "Datarepo chart version update: ${{ steps.chartversion.outputs.version }}"
+          SWITCH_DIRECTORIES: "true"
 
       - name: "Notify Slack"
         if: ${{ inputs.notify-slack && always() }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           version: v3.4.0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         with:
           version: v3.4.0
 


### PR DESCRIPTION
See https://github.com/DataBiosphere/jade-data-repo/pull/1404 PR description for more details about the changes.

### Testing
Successful runs against this branch - I commented out the steps that actually do the real work so that I could test out the workflows. There is a small chance things break after uncommenting, but testing these workflows out of cycle can get us into a very wonky state that I'd like to avoid.

- Alpha Chart promotion ([case where notify-slack was set to false](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120031778/jobs/7114351712))  ([case set to true](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120047251))
- Chart releaser ([case where notify-slack was set to false](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120056626))  ([case set to true](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120051876))
- Integration Chart Bump ([case where notify-slack was set to false](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120062584))  ([case set to true](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120061740))
- Lint (see latest PR run)
- Release DR ([notify-slack = true](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120071677)) ([notify-slack = false](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120074718/jobs/7114435593))
- [Release DR Umbrella ](https://github.com/broadinstitute/datarepo-helm/actions/workflows/releasedrumbrella.yaml)
- [Release Non DR Umbrella](https://github.com/broadinstitute/datarepo-helm/actions/runs/4120092688)