### PR TITLE
DDO-2815 add datarepo-latest bump + test runs

### DIFF
--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -115,7 +115,7 @@ jobs:
       new-version: ${{ needs.release_new_umbrella_dr.outputs.new-version }}
       parent-chart-version: ${{ needs.release_new_umbrella_dr.outputs.parent-chart-version }}
       chart-name: "datarepo"
-  # setsthe new umbrella chart version in the datarepo-latest terra template in sherlock.
+  # sets the new umbrella chart version in the datarepo-latest terra template in sherlock.
   set-chart-version-in-datarepo-latest:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-chart-version.yaml@main
     needs:


### PR DESCRIPTION
Adds another step to the datarepo umbrella chart release:
update `datarepo-latest` template with the new umbrella release chart, this is required for immediately release promotions because
1) datarepo develop is not managed by devops and doesn't share the same versions as terra (semantic versioning)
2) alpha is only deployed to once a day so does not work for up-to-date constant testing.

tested here: https://github.com/broadinstitute/datarepo-helm/actions/runs/4886580347
- confirmed `datarepo-datarepo-latest` bumped from `0.1.705` to `0.1.706`