### PR TITLE
DR-3144 Allow encoded slashes (%2F) to be passed through by the apache proxy

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.41
-appVersion: 0.0.41
+version: 0.0.42
+appVersion: 0.0.42
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -66,6 +66,10 @@ data:
         RewriteCond %{REQUEST_URI}  !^/(version|status) [NC]
         SSLProxyEngine on
 
+        # Note: we need to set AllowEncodedSlashes to NoDecode to allow the encoded slashes in the DRS object ID to pass
+        # through to the service.
+        AllowEncodedSlashes NoDecode
+    
         ErrorLog /dev/stdout
         CustomLog "/dev/stdout" combined
 
@@ -167,7 +171,9 @@ data:
             RequestHeader set oidc_access_token "expr=%{HTTP:OAUTH2_CLAIM_access_token}"
             RequestHeader set oidc_claim_expires_in "expr=%{HTTP:OAUTH2_CLAIM_exp}"
 
-            ProxyPass ${PROXY_URL3}
+            # nocanon ensures that any encoded slashes in the DRS object ID are passed through to the service as is and not encoded further
+            # E.g. without that flag, foo%2Fbar would be passed through as foo%252Fbar (the % would be encoded as %25)
+            ProxyPass ${PROXY_URL3} nocanon
             ProxyPassReverse ${PROXY_URL3}
 
             ${FILTER3}


### PR DESCRIPTION
Note: per the docs, taking the safer method of not decoding the %2Fs but jst passing them through (which is actually what we want behavior-wise).  It's the API service's responsibility to understand what to do with the %2F characters.

The current behavior that this is replacing is to throw a 404 when a user passes in a %2F in the URL