### PR TITLE
[DR-2890] Update deprecated Github Actions set-output commands

### DIFF
--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -52,7 +52,7 @@ jobs:
           do
             CHART_VERSION=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/$i/Chart.yaml 'version')
             echo "New $i version $CHART_VERSION"
-            echo "::set-output name=$i-version::$CHART_VERSION"
+            echo "$i-version=$CHART_VERSION" >> $GITHUB_OUTPUT
             
           done
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/terraAlphaChartBump.yaml
+++ b/.github/workflows/terraAlphaChartBump.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: "Find latest version of Datarepo chart version in datarepo/Chart.yaml"
         id: chartversion
         run: |
-          echo "::set-output name=version::$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/datarepo/Chart.yaml version)"
+          echo "version=$(docker run --rm -v ${PWD}:/workdir mikefarah/yq:3 yq read datarepo-helm/charts/datarepo/Chart.yaml version)" >> $GITHUB_OUTPUT
 
       - name: "Find and replace Datarepo chartVersion version in alpha action"
         uses: docker://mikefarah/yq:3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - id: auth


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-2890

The save-state and set-output commands are going to be deprecated in Github Actions. This PR updates the syntax for set-output (save-state is not used anywhere). Here is more context about this change: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/