### PR TITLE
[DDO-3199] Make it possible to pass in TDR deployment annotations in values files

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,8 +12,8 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.542
-appVersion: 1.537.0
+version: 0.0.543
+appVersion: 1.536.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application
 # appVersion: 1.16.0

--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.541
+version: 0.0.542
 appVersion: 1.535.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/templates/api-deployment.yaml
+++ b/charts/datarepo-api/templates/api-deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ include "datarepo-api.fullname" . }}
   labels:
     {{- include "datarepo-api.labels" . | nindent 4 }}
-
+  {{- if .Values.deploymentAnnotations }}
+  annotations: {{- .Values.deploymentAnnotations | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ if (($.Values).global).replicasOffline | default false -}}
       0

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -23,6 +23,8 @@ nameOverride: ""
 fullnameOverride: ""
 ## Pod annotations
 podAnnotations: {}
+## Deployment annotations
+deploymentAnnotations: {}
 ## Node selectors and tolerations for server scheduling to nodes with taints
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 ##


### PR DESCRIPTION
This will allow us to configure reloader to restart TDR when its service account key is rotated.

### Testing

I'm not sure the best way to test this under TDR's current setup. I rendered the chart locally with `helm template` and a values override and verified that the annotations are substituted in correctly:
```
kind: Deployment
metadata:
  name: RELEASE-NAME-datarepo-api
  labels: <...snip...>
  annotations:
    a: "2"
    foo: bar
```