### PR TITLE
[DR-3413] Use new datarepo-umbrella-release-action

### DIFF
--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -71,7 +71,7 @@ jobs:
           cmd: echo "version=$(yq '.version' charts/datarepo/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: "Create new umbrella chart"
-        uses: broadinstitute/datarepo-umbrella-release-action@0.3.0
+        uses: broadinstitute/datarepo-umbrella-release-action@0.4.0
 
       # This step expects the previous datarepo-umbrella-release-action to
       # edit the code downloaded in Checkout step on the runner filesystem


### PR DESCRIPTION
After https://github.com/broadinstitute/datarepo-helm/pull/247 was merged, the [datarepo-umbrella-release-action](https://github.com/broadinstitute/datarepo-umbrella-release-action/blob/99ab90f152de7ccc8c306ad751bac2719592ce76/action.yaml#L13) failed because it was still trying to include the `de-elasticsearch` chart. The new version of this action removes `de-elasticsearch` from the list of charts included in the umbrella chart.