### PR TITLE
Attempting to Fix TDR in Bees following upgrade to GKE 1.25

### DIFF
--- a/charts/datarepo-api/templates/pod-running-policy.yaml
+++ b/charts/datarepo-api/templates/pod-running-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pspEnabled }}
+{{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/datarepo-api/templates/pod-running-policy.yaml
+++ b/charts/datarepo-api/templates/pod-running-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/datarepo-api/templates/pod-running-policy.yaml
+++ b/charts/datarepo-api/templates/pod-running-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled }}
+{{- if .Values.rbac.create | and .Values.rbac.pspEnabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 {{- if .Values.rbac.pspEnabled -}}
+=======
+{{- if .Values.rbac.create | and .Values.pspEnabled -}}
+>>>>>>> 43912b03 (separate values)
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-{{- if .Values.rbac.pspEnabled -}}
-=======
 {{- if .Values.rbac.create | and .Values.pspEnabled -}}
->>>>>>> 43912b03 (separate values)
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.pspEnabled -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pspEnabled -}}
+{{- if .Values.rbac.pspEnabled -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/role.yaml
+++ b/charts/datarepo-api/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create | and .Values.pspEnabled -}}
+{{- if .Values.rbac.create | and .Values.rbac.pspEnabled -}}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/rolebinding.yaml
+++ b/charts/datarepo-api/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.pspEnabled -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/rolebinding.yaml
+++ b/charts/datarepo-api/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pspEnabled -}}
+{{- if .Values.rbac.pspEnabled -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/templates/rolebinding.yaml
+++ b/charts/datarepo-api/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.pspEnabled -}}
+{{- if .Values.rbac.create | and .Values.rbac.pspEnabled -}}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -48,6 +48,7 @@ rbac:
   create: false
   # If true, prefix the psp with the release's namespace. (Used to prevent conflicts in BEEs)
   namespacePrefix: false
+pspEnabled: true
 service:
   port: 8080
   type: ClusterIP

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -48,7 +48,7 @@ rbac:
   create: false
   # If true, prefix the psp with the release's namespace. (Used to prevent conflicts in BEEs)
   namespacePrefix: false
-pspEnabled: true
+  pspEnabled: true
 service:
   port: 8080
   type: ClusterIP


### PR DESCRIPTION
The old rbac enabled flag wrapped both both pod security policy associated resources and also tdr's permission to talk to the k8s api. This separates them so that we can disable pod security policy without breaking tdrs ability to talk to k8s.

All bee creations are currently failing because of this. 
