### PR TITLE
[DDO-3475] Bump chart versions

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.598
+version: 0.0.599
 appVersion: 1.592.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -28,7 +28,7 @@ sources:
 # dependencies
 dependencies:
 - name: datarepo-api
-  version: 0.0.598
+  version: 0.0.599
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: datarepo-api.enabled
 - name: oidc-proxy


### PR DESCRIPTION
I failed to bump chart versions correctly in https://github.com/broadinstitute/datarepo-helm/pull/249; this is a correction.