### PR TITLE
DC-902: bump datarepo-actions

### DIFF
--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -82,7 +82,7 @@ jobs:
           args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
 
       - name: "[${{ matrix.repo }}] Merge multi chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
           GITHUB_REPO: ${{ matrix.repo }}

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -84,7 +84,7 @@ jobs:
           cmd: echo "version=$(yq '.version' charts/datarepo/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: "[datarepo-helm] Merge in changes to umbrella chart"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
         env:
           COMMIT_MESSAGE: "Datarepo umbrella chart update"
           GITHUB_REPO: datarepo-helm


### PR DESCRIPTION
Bump to the latest version. 
This repo was not impacted by the issue described in DC-802, but it's still ideal to keep these versions up to date.