### PR TITLE
[PROD-934] Revert "bump datarepo-actions (#252)"

### DIFF
--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -82,7 +82,7 @@ jobs:
           args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
 
       - name: "[${{ matrix.repo }}] Merge multi chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
           GITHUB_REPO: ${{ matrix.repo }}

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -84,7 +84,7 @@ jobs:
           cmd: echo "version=$(yq '.version' charts/datarepo/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: "[datarepo-helm] Merge in changes to umbrella chart"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.71.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.66.0
         env:
           COMMIT_MESSAGE: "Datarepo umbrella chart update"
           GITHUB_REPO: datarepo-helm


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-934

This reverts commit [2edd43f4bf7f7e673495a54b777950e7269480b6](https://github.com/broadinstitute/datarepo-helm/commit/2edd43f4bf7f7e673495a54b777950e7269480b6) from https://github.com/broadinstitute/datarepo-helm/pull/252

The commit was not strictly necessary to correct the issue at hand.  Following the merge, [API chart sync has been failing in all environments](https://github.com/broadinstitute/terra-github-workflows/actions/runs/8161732182), and we are attempting to triangulate the cause.