### PR TITLE
[PROD-934] TDR gcloud-sqlproxy conditionally disables PodSecurityPolicies

### DIFF
--- a/charts/gcloud-sqlproxy/Chart.yaml
+++ b/charts/gcloud-sqlproxy/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 name: gcloud-sqlproxy
 sources:
 - https://github.com/broadinstitute/datarepo-helm
-version: 0.19.9
+version: 0.19.10

--- a/charts/gcloud-sqlproxy/templates/podrunningpolicy.yaml
+++ b/charts/gcloud-sqlproxy/templates/podrunningpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if .Values.rbac.create | and .Values.rbac.pspEnabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/gcloud-sqlproxy/templates/role.yaml
+++ b/charts/gcloud-sqlproxy/templates/role.yaml
@@ -13,11 +13,13 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get", "watch", "list"]
+{{- if .Values.rbac.pspEnabled -}}
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']
   verbs: ["use"]
   resourceNames:
     - {{ include "gcloud-sqlproxy.fullname" . }}
+{{- end }}
 
 
 {{- end }}

--- a/charts/gcloud-sqlproxy/values.yaml
+++ b/charts/gcloud-sqlproxy/values.yaml
@@ -59,6 +59,7 @@ cloudsql:
 
 rbac:
   create: false
+  pspEnabled: true
 
 ## Specifies service type and option to enable internal LoadBalancer
 ## If service.internalLB is true, service.type should be: LoadBalancer


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-934

This is a follow-on to https://github.com/broadinstitute/datarepo-helm/pull/249 which only made the necessary changes for TDR Bees to be compatible with GKE 1.25. TDR Bees don't use the `gcloud-sqlproxy`, and the existing `rbac.create` flag enabled more than just resources associated with PodSecurityPolicies, so I've added an additional `rbac.pspEnabled` flag to toggle only those resources without impacting other necessary operations (such as SA creation).

Defaulted this value to true to keep existing behavior the same.
- We will then disable it for each environment starting with Dev: https://github.com/broadinstitute/terra-helmfile/pull/5216
- … and likely cut it out altogether once everything is stable.

Bumped the `gcloud-sqlproxy` chart patch version.