### PR TITLE
[DR-3440] Swap openidc-terra-proxy for httpd-terra-proxy v0.1.18

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.42
-appVersion: 0.0.42
+version: 0.0.43
+appVersion: 0.0.43
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -46,15 +46,6 @@ data:
     Header merge Vary Origin
 
     ProxyTimeout ${PROXY_TIMEOUT}
-    OIDCOAuthTokenIntrospectionInterval 60
-    # Enabling cache encryption via 'OIDCCacheEncrypt On' has two side effects:
-    # 1. it reduces key size to avoid "could not construct cache key since key size is too large" cache errors
-    # 2. it causes intermittent duplicate requests between the proxy and the underlying app
-    # the latter side effect is too dangerous, so cache encryption is off
-    OIDCCacheEncrypt Off
-    # Use GET for the introspection endpoint to avoid a performance issue with POST requests.
-    # See https://broadworkbench.atlassian.net/browse/PROD-634
-    OIDCOAuthIntrospectionEndpointMethod GET
 
     <VirtualHost _default_:${HTTPD_PORT}>
         ServerAdmin ${SERVER_ADMIN}

--- a/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
+++ b/charts/oidc-proxy/templates/oidc-proxy-deployment.yaml
@@ -73,14 +73,14 @@ spec:
         {{- end }}
         volumeMounts:
           {{- if .Values.tcell.enabled }}
-          - mountPath: /etc/apache2/tcell_agent.config
+          - mountPath: /etc/httpd/tcell_agent.config
             name: tcellconf
             subPath: tcell_agent.config
           {{- end }}
-          - mountPath: /etc/apache2/sites-available/site.conf
+          - mountPath: /etc/httpd/conf.d/site.conf
             name: siteconf
             subPath: site.conf
-          - mountPath: /etc/apache2/mods-enabled/oauth2.conf
+          - mountPath: /etc/httpd/conf.d/oauth2.conf
             name: oauth2conf
             subPath: oauth2.conf
       volumes:

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Versions can be found here:
 ## https://github.com/broadinstitute/openidc-terra-proxy/tags
 image:
-  repository: us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy
+  repository: us.gcr.io/broad-dsp-gcr-public/openidc-terra-proxy
   version: v0.1.18
   pullPolicy: IfNotPresent
 

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 ## https://github.com/broadinstitute/openidc-terra-proxy/tags
 image:
   repository: us.gcr.io/broad-dsp-gcr-public/openidc-terra-proxy
-  version: v0.1.12
+  version: v0.1.18
   pullPolicy: IfNotPresent
 
 ## Extra environment variables that will be pass onto deployment pods

--- a/charts/oidc-proxy/values.yaml
+++ b/charts/oidc-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Versions can be found here:
 ## https://github.com/broadinstitute/openidc-terra-proxy/tags
 image:
-  repository: us.gcr.io/broad-dsp-gcr-public/openidc-terra-proxy
+  repository: us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy
   version: v0.1.18
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DR-3440

This change comes after several PROD incidents related to TDR's oidc-proxy, often requiring a manual refresh of the deployment to bring systems back in operation.  This upgrade matches what the rest of Terra uses, and is the latest available version.

PROD incidents:
- https://broadworkbench.atlassian.net/browse/PROD-926
- https://broadworkbench.atlassian.net/browse/PROD-934 (possibly related)
- https://broadworkbench.atlassian.net/browse/PROD-938

Per @rtitle - 'There were some significant changes between then: switch to RedHat UBI base image; concurrency bugfix in the mod_oauth2 module; remove stackdriver agent; and improved graceful shutdown.' 

This change was not quite a drop-in replacement, and required the following modifications:

1. httpd uses different path mounts, used https://github.com/broadinstitute/terra-helmfile/pull/3247/files as a reference to update.
2. OIDC* directives are obsolete now that we use mod_oauth2, configured in /charts/oidc-proxy/templates/configmap.yaml:data.oauth2conf.  Leaving them in yielded errors like 'Invalid command 'OIDCOAuthTokenIntrospectionInterval', perhaps misspelled or defined by a module not included in the server configuration'.

**Manual Verification**
https://jade-ok.datarepo-dev.broadinstitute.org/ has been updated with httpd-terra-proxy v0.1.18.  I can log into my dev TDR and perform some basic authenticated click testing.

GCP console entry: https://console.cloud.google.com/kubernetes/deployment/us-central1/dev-master/ok/ok-jade-oidc-proxy/overview?project=broad-jade-dev

<img width="1205" alt="Screenshot 2024-03-07 at 3 54 07 PM" src="https://github.com/broadinstitute/datarepo-helm/assets/79769153/bee45e3c-a08e-4036-84c7-a2e18d450af4">

