### PR TITLE
DDO-3517: Set empty list for vault secrets

### DIFF
--- a/charts/create-secret-manager-secret/Chart.yaml
+++ b/charts/create-secret-manager-secret/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.7
-appVersion: 0.0.7
+version: 0.0.8
+appVersion: 0.0.8
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 keywords:

--- a/charts/create-secret-manager-secret/values.yaml
+++ b/charts/create-secret-manager-secret/values.yaml
@@ -1,4 +1,4 @@
-secrets:
+secrets: []
 
 # - secretName:     ## name of kubeSecret
 #  nameSpace: ""


### PR DESCRIPTION
This is the 3rd of 5 PRs to migrate data repo to ESO from Vault. This PR is an intermediate between adding ESO secrets ([1](https://github.com/broadinstitute/datarepo-helm/pull/253) [2](https://github.com/broadinstitute/terra-helmfile/pull/5213)) and cutover to ESO ([4](https://github.com/broadinstitute/terra-helmfile/pull/5296) [5](https://github.com/broadinstitute/datarepo-helm/pull/261)). This repo (datarepo-helm) will hold the create-secret-manager-secret chart while terra-helmfile will hold the values.

This PR sets `secrets` (list of vault secrets) to `[]`. This is in preparation for when we deleted the Vault values from terra-helmfile (PR 4) but before the Vault secret parsing is removed from the datarepo-helm chart (PR 5).

This PR was tested by using [the datarepo-helm-definitions repo](https://github.com/broadinstitute/datarepo-helm-definitions). Using Olivia's setup, I pointed the chart to my local updated version of the create-secret-manager-secrets chart, after updating the values file in the definitions repos. I also pointed the values to my local versions of the terra-helmfile values files for dev, staging, prod, and BEEs.


helmfile.yaml:
```
# helm releases to be deployed
releases:
  - name: ok-jade-create-secret-manager-secret    # release name
    namespace: ok   # target namespace
    createNamespace: true
    #chart: datarepo-helm/create-secret-manager-secret   # chart name    
    chart: /Users/welchkat/Documents/src/datarepo-helm/charts/create-secret-manager-secret   # chart name
    missingFileHandler: Warn
    values:
      #- create-secret-manager-secret.yaml      # Value files passed via --values
      - /Users/welchkat/Documents/src/datarepo-helm/charts/create-secret-manager-secret/values.yaml
```

After running `helmfile apply`, for each iteration of my local chart and values files, I confirmed the output matches what I expect.