### PR TITLE
DDO-3415 Add support for Prometheus ServiceMonitor Resource to datarepo-api

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.645
+version: 0.0.646
 appVersion: 2.39.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.644
+version: 0.0.645
 appVersion: 2.38.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/templates/service-monitor.yaml
+++ b/charts/datarepo-api/templates/service-monitor.yaml
@@ -16,7 +16,7 @@ spec:
     matchLabels:
       {{- include "datarepo-api.selectorLabels" . | nindent 6 }}
   endpoints:
-    - port: {{ .Values.service.port }}
+    - port: http
       interval: {{ .Values.prometheus.scrape.interval }}
       path: {{ .Values .prometheus.scrape.path }}
       scheme: {{ .Values.prometheus.scrape.scheme }}

--- a/charts/datarepo-api/templates/service-monitor.yaml
+++ b/charts/datarepo-api/templates/service-monitor.yaml
@@ -1,5 +1,5 @@
-# Service Monitor is a custom kubernetes resource that defines how Prometheus should scrape metrics from a service
-# It also automatically includes information such as  k8s namespace and deployment name etc in the metric labels
+{{/* Service Monitor is a custom kubernetes resource that defines how Prometheus should scrape metrics from a service
+ It also automatically includes information such as  k8s namespace and deployment name etc in the metric labels */}}
 {{- if ((.Values.prometheus).scrape).enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/datarepo-api/templates/service-monitor.yaml
+++ b/charts/datarepo-api/templates/service-monitor.yaml
@@ -1,0 +1,25 @@
+# Service Monitor is a custom kubernetes resource that defines how Prometheus should scrape metrics from a service
+# It also automatically includes information such as  k8s namespace and deployment name etc in the metric labels
+{{- if ((.Values.prometheus).scrape).enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "datarepo-api.fullname" . }}-prometheus-scrape-servicemonitor
+  labels: 
+    {{- include "datarepo-api.labels" . | nindent 4 }}
+spec:
+  jobLabel: {{ include "datarepo-api.fullname" . }}-prometheus-scrape-job
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "datarepo-api.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ .Values.service.port }}
+      interval: {{ .Values.prometheus.scrape.interval }}
+      path: {{ .Values .prometheus.scrape.path }}
+      scheme: {{ .Values.prometheus.scrape.scheme }}
+      scrapeTimeout: {{ .Values.prometheus.scrape.timeout }}
+      honorLabels: true
+{{- end }}

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -99,3 +99,17 @@ sherlock:
   vault:
     # client certificate credentials used to authenticate to sherlock
     pathPrefix: secret/suitable/sherlock/prod
+
+prometheus:
+  # -- configuration for scraping TDR metrics provided via Spring Actuator
+  scrape:
+    # -- whether to enable scraping of metrics
+    enabled: false
+    # -- the interval at which to scrape metrics
+    interval: 15s
+    # -- the path to scrape metrics from
+    path: /actuator/prometheus
+    # -- the scheme to use for scraping
+    scheme: http
+    # -- the timeout for scraping
+    timeout: 10s


### PR DESCRIPTION
This adds support for creation of the [`ServiceMonitor`](https://prometheus-operator.dev/docs/operator/design/#servicemonitor) kubernetes resource extension that can be used by prometheus to automatically discover and pull metrics from a targeted set of k8s pods.

The advantage of this approach is that it automatically tags all timeseries collected via this method with relevant k8s metadata such as namespace, which deployment/container it is etc...

This is the same method used by the rest of Terra for collecting these metrics. It is a replacement for [this approach](https://github.com/broadinstitute/datarepo-helm-definitions/blob/d3a2b0ae1f78468f425a0889c9b6b7a9c3f1a469/dev/monitoring/kube-prometheus-stack.yaml#L18) in the TDR prometheus which achieves a similar goal scraping the metric data from TDR pods. However it is not able to differentiate between multiple different TDR deployments in the same cluster or tag the metrics with other relevant k8s info.

This will also make metrics from TDR in Bees start populating in Grafana as well.