### PR TITLE
[DCJ-31] Remove Slack notifications from PR lint action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,17 +42,3 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/lint-config.yaml
-
-      - name: "Notify Slack"
-        if: always()
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message
-          channel: "#jade-spam"
-          username: "datarepo-helm actions"
-          text: "Helm Chart Lint"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-31

The Helm Chart Linter runs only on commits to PRs. Slack notifications on the outcome are unnecessary and noisy. If the action fails, the PR cannot be merged.

Current state of [#jade-spam](https://broadinstitute.slack.com/archives/CK9M0ENRJ/p1713300313079569) (which Data Custodian Journeys team is in the process of auditing and consolidating):
<img width="494" alt="Screenshot 2024-04-16 at 6 00 46 PM" src="https://github.com/broadinstitute/datarepo-helm/assets/79769153/2ac30e79-1a86-4ae1-b170-01e189ed05f7">

Confirming that when this PR's lint run ran and succeeded, no notification was emitted to #jade-spam.
