### PR TITLE
[DCJ-28] Slack DCJ team on release failures, retries

### DIFF
--- a/.github/workflows/chart-releaser.yaml
+++ b/.github/workflows/chart-releaser.yaml
@@ -1,16 +1,8 @@
 name: Release helm charts
 
 on:
-  workflow_dispatch:
-    inputs:
-      notify-slack:
-        default: true
-        type: boolean
-  workflow_call:
-    inputs:
-      notify-slack:
-        default: false
-        type: boolean
+  workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   release_chart:
@@ -42,17 +34,3 @@ jobs:
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
-
-      - name: "Notify Slack"
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message
-          channel: "#jade-spam"
-          username: "datarepo-helm actions"
-          text: "Release Helm Charts"

--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -3,16 +3,8 @@ env:
   charts: gcloud-sqlproxy datarepo-api datarepo-ui oidc-proxy create-secret-manager-secret
 
 on:
-  workflow_dispatch:
-    inputs:
-      notify-slack:
-        default: true
-        type: boolean
-  workflow_call:
-    inputs:
-      notify-slack:
-        default: false
-        type: boolean
+  workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   indivdual_chart_promotion:
@@ -89,20 +81,6 @@ jobs:
       - name: "[${{ matrix.repo }}] Merge multi chart version update"
         uses: broadinstitute/datarepo-actions/actions/merger@0.73.0
         env:
-          COMMIT_MESSAGE: "Datarepo Integration mutli chart version update"
+          COMMIT_MESSAGE: "Datarepo Integration multi chart version update"
           GITHUB_REPO: ${{ matrix.repo }}
           SWITCH_DIRECTORIES: "true"
-
-      - name: "Notify Slack"
-        if: ${{ inputs.notify-slack && always() }}
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message
-          channel: "#jade-spam"
-          username: "datarepo-helm actions"
-          text: "Integration Chart Promotion"

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -1,16 +1,8 @@
 name: Create chart Datarepo chart
 
 on:
-  workflow_dispatch:
-    inputs:
-      notify-slack:
-        default: true
-        type: boolean
-  workflow_call:
-    inputs:
-      notify-slack:
-        default: false
-        type: boolean
+  workflow_dispatch: {}
+  workflow_call: {}
   push:
     branches:
       - master
@@ -90,20 +82,6 @@ jobs:
           GITHUB_REPO: datarepo-helm
           MERGE_BRANCH: master
 
-      - name: "Notify Slack"
-        if: ${{ (github.event_name == 'push' && always()) || (inputs.notify-slack && always()) }} # workflow_call has own slack notification
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
-        with:
-          status: ${{ job.status }}
-          fields: job,repo,message
-          channel: "#jade-spam"
-          username: "datarepo-helm actions"
-          text: "Create Datarepo Chart"
-
   report-chart-to-sherlock:
     name: Report Chart Version to DevOps
     needs: [release_new_umbrella_dr]
@@ -128,5 +106,14 @@ jobs:
       environment-name: dev
     secrets:
       sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: write
+
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
     permissions:
       id-token: write

--- a/.github/workflows/releasedrumbrella.yaml
+++ b/.github/workflows/releasedrumbrella.yaml
@@ -29,23 +29,11 @@ jobs:
     needs: release_new_umbrella_dr
     uses: ./.github/workflows/integrationChartBump.yaml
     secrets: inherit
-  notify_slack:
-    needs:
-      - release_new_umbrella_dr
-      - release_umbrella_helm_charts
-      - integration_chart_promotion
-    runs-on: ubuntu-latest
-    if: always()
-    steps:
-      - name: "Notify Slack"
-        uses: broadinstitute/action-slack@v3.15.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required to work with job field
-        with:
-          status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
-          fields: job,repo,message
-          channel: "#jade-spam"
-          username: "datarepo-helm actions"
-          text: "Release Datarepo Chart"
+  report-workflow:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-workflow.yaml@main
+    with:
+      relates-to-chart-releases: 'datarepo-dev'
+      notify-slack-channels-upon-workflow-failure: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+      notify-slack-channels-upon-workflow-retry: ${{ vars.SLACK_NOTIFICATION_CHANNELS }}
+    permissions:
+      id-token: write


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/DCJ-28

More thorough background: https://github.com/DataBiosphere/jade-data-repo/pull/1654

I set up a new Github repository variable `SLACK_NOTIFICATION_CHANNELS`:

<img width="1400" alt="Screenshot 2024-04-19 at 10 20 14 AM" src="https://github.com/broadinstitute/datarepo-helm/assets/79769153/cf3b7920-d7c5-4059-b242-8edd47974424">

And made the following changes to existing Slack notifications:

- `chart-releaser`, `integrationChartBump`: removed Slack notifications as these are called within `releasedrumbrella`.
- `releasedr`, `releasedrumbrella`: reworked Slack notifications to be emitted by Sherlock on failures or retries to our variable-driven channel list.
  - I think we should have the insight we need into deployments from Beehive's Slack deploy hooks, but I am not confident enough to fully remove them.  If / when these fail, we can take a closer look at the full suite of notifications that go out and pare down as needed.