### PR TITLE
bump to v40

### DIFF
--- a/charts/datarepo/Chart.yaml
+++ b/charts/datarepo/Chart.yaml
@@ -48,6 +48,6 @@ dependencies:
   repository: https://broadinstitute.github.io/datarepo-helm/
   condition: create-secret-manager-secret.enabled
 - name: postgres
-  version: 0.26.0
+  version: 0.40.0
   repository: https://terra-helm.storage.googleapis.com/
   condition: postgres.enabled


### PR DESCRIPTION
bumps postgres chart from 0.26.0 to 0.40.0, only affects bees