### PR TITLE
[DCJ-470] Increase datarepo-api pod memory limit

### DIFF
--- a/charts/datarepo-api/Chart.yaml
+++ b/charts/datarepo-api/Chart.yaml
@@ -12,7 +12,7 @@ description: A Helm chart to deploy datarepo api server for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.700
+version: 0.0.701
 appVersion: 2.94.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application

--- a/charts/datarepo-api/values.yaml
+++ b/charts/datarepo-api/values.yaml
@@ -33,9 +33,9 @@ tolerations: []
 affinity: {}
 resources:
   limits:
-    memory: 2560Mi
+    memory: 4.5Gi
   requests:
-    memory: 1536Mi
+    memory: 1.5Gi
 serviceAccount:
   annotations: {}
   # Specifies whether a service account should be created


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DCJ-470

## Addresses

Since the beginning of 2024, TDR Prod backend pods have triggered high memory alerts (>95% of limit) over 50 times.  We'd like to increase the memory limits on our backend pods for increased system reliability and decreased alerting noise.

This PR partially fulfills the ticket above.  We must roll out PRs in the following order:
1. This PR
2. https://github.com/DataBiosphere/jade-data-repo/pull/1727 (because the Docker memory limit should be less than the pod memory limit)

## Summary of changes

Increase `datarepo-api` pod memory limit, and convert memory configuration values from Mi to Gi for easier readability, following precedent set by other services in `terra-helmfile`.

- `resources.limits.memory` increased from 2.5Gi -> 4.5Gi
- `resources.requests.memory` unchanged at 1.5Gi (but converted from Mi for readability)

The companion jade-data-repo PR increases the Docker container's memory limit to 4g, which converts to 3.73 Gi and is below the pod's memory limit (that's what we want).

## Post-Deployment Verification

After this change is deployed to dev, I'll check in [Grafana](https://grafana.dsp-devops.broadinstitute.org/d/3oRYUysSz/terra-data-repository-tdr?orgId=1&var-cluster=datarepo-dev&var-container=dev-jade-datarepo-api&var-namespace=dev&var-project=&var-executor_name=azureTableThreadpool&viewPanel=52) to confirm that the backend pods have an updated memory limit.