### PR TITLE
DCJ-476: Specify the latest merger action version

### DIFF
--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -79,7 +79,7 @@ jobs:
           args: yq r ${{ matrix.repo }}/.github/workflows/${{ matrix.filename }}
 
       - name: "[${{ matrix.repo }}] Merge multi chart version update"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.74.0
         env:
           COMMIT_MESSAGE: "Datarepo Integration multi chart version update"
           GITHUB_REPO: ${{ matrix.repo }}

--- a/.github/workflows/releasedr.yaml
+++ b/.github/workflows/releasedr.yaml
@@ -76,7 +76,7 @@ jobs:
           cmd: echo "version=$(yq '.version' charts/datarepo/Chart.yaml)" >> $GITHUB_OUTPUT
 
       - name: "[datarepo-helm] Merge in changes to umbrella chart"
-        uses: broadinstitute/datarepo-actions/actions/merger@0.73.0
+        uses: broadinstitute/datarepo-actions/actions/merger@0.74.0
         env:
           COMMIT_MESSAGE: "Datarepo umbrella chart update"
           GITHUB_REPO: datarepo-helm


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-476

Update the specified versions of the merger action call as updated in https://github.com/broadinstitute/datarepo-actions/pull/85