### PR TITLE
[ID-1364] Allow x-transaction-id header from DrsHub

### DIFF
--- a/charts/oidc-proxy/Chart.yaml
+++ b/charts/oidc-proxy/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.44
-appVersion: 0.0.44
+version: 0.0.45
+appVersion: 0.0.45
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 

--- a/charts/oidc-proxy/templates/configmap.yaml
+++ b/charts/oidc-proxy/templates/configmap.yaml
@@ -18,12 +18,12 @@ data:
     CustomLog "/dev/stdout" combined env=!forwarded
     CustomLog "/dev/stdout" proxy env=forwarded
     LogLevel ${LOG_LEVEL}
-    
+
     AddType application/x-httpd-php .php
 
     Header unset X-Frame-Options
     Header always set X-Frame-Options SAMEORIGIN
-    Header always set Access-Control-Allow-Headers DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Referer,X-App-Id,Origin
+    Header always set Access-Control-Allow-Headers DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Accept,Referer,X-App-Id,Origin,x-transaction-id
     Header always set Access-Control-Allow-Methods GET,POST,DELETE,PUT,PATCH,OPTIONS,HEAD
     Header always set X-Content-Type-Options nosniff
     Header always set Strict-Transport-Security max-age=31536000;includeSubDomains
@@ -60,16 +60,16 @@ data:
         # Note: we need to set AllowEncodedSlashes to NoDecode to allow the encoded slashes in the DRS object ID to pass
         # through to the service.
         AllowEncodedSlashes NoDecode
-    
+
         ErrorLog /dev/stdout
         CustomLog "/dev/stdout" combined
 
         DocumentRoot /app
-        
+
         <Directory "/app">
           AllowOverride All
           Options -Indexes
-          
+
           Order allow,deny
           Allow from all
         </Directory>
@@ -79,7 +79,7 @@ data:
             Require all granted
             AuthType None
         </Location>
-    
+
         <LocationMatch "^(?!/introspect/)(${PROXY_PATH})(.*)">
             RewriteEngine On
             RewriteCond %{REQUEST_METHOD} OPTIONS
@@ -183,7 +183,7 @@ data:
             ProxyPass https://bigquery.googleapis.com/bigquery
             ProxyPassReverse https://bigquery.googleapis.com/bigquery
         </Location>
-    
+
         <Location /googlesheets>
           ProxyPass https://sheets.googleapis.com
           ProxyPassReverse https://sheets.googleapis.com


### PR DESCRIPTION
**Ticket:** https://broadworkbench.atlassian.net/browse/ID-1364

**Changes:**
Allow the "x-transaction-id" header sent from DrsHub. This will make it easier to connect the Bard logs from DrsHub and TDR for a given DRS resolution request.