### PR TITLE
[DCJ-616] Do not update action anymore

### DIFF
--- a/.github/workflows/integrationChartBump.yaml
+++ b/.github/workflows/integrationChartBump.yaml
@@ -11,10 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - app: datarepo-api
-            repo: "jade-data-repo"
-            filename: "int-and-connected-test-run.yml"
-            jobname: "deploy_test_integration"
           - app: datarepo-ui
             repo: "jade-data-repo-ui"
             filename: "test-e2e.yml"


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DCJ-616

## Summary

In TDR, Changes were recently made to the action which runs on PRs:

- https://github.com/DataBiosphere/jade-data-repo/pull/1781 
- https://github.com/DataBiosphere/jade-data-repo/pull/1794

This workflow tries to (unsuccessfully) modify the action, breaking it in the process:

https://github.com/DataBiosphere/jade-data-repo/commit/31b4714b0032fcc4c982e64709c68ce45e576fa6

Links to failed builds:

https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708679629
https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708678706
https://github.com/DataBiosphere/jade-data-repo/actions/runs/10708668823